### PR TITLE
Timeline refactor on basic layer groups

### DIFF
--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -380,7 +380,7 @@ func blend_layers(image: Image, frame: Frame, origin: Vector2 = Vector2(0, 0)) -
 	image.lock()
 	var layer_i := 0
 	for cel in frame.cels:
-		# TODO: Check
+		# TODO H: Check
 		if Global.current_project.layers[layer_i].visible and not cel is GroupCel:
 			var cel_image := Image.new()
 			cel_image.copy_from(cel.image)

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -255,7 +255,7 @@ func undo_or_redo(
 			cursor_position_label.text = "[%s×%s]" % [project.size.x, project.size.y]
 
 	elif "Frame" in action_name:
-		# TODO R: Does what this comment says after the refacotr remain true? (Perhaps this should be moved to move_frame?)
+		# TODO R2: Does what this comment says after the refacotr remain true? (Perhaps this should be moved to move_frame?)
 		# This actually means that frames.size is one, but it hasn't been updated yet
 		if (undo and project.frames.size() == 2) or project.frames.size() == 1:  # Stop animating
 			play_forward.pressed = false
@@ -263,7 +263,7 @@ func undo_or_redo(
 			animation_timer.stop()
 
 	elif "Move Cels" == action_name:
-		# TODO R: is this still required?
+		# TODO R2: is this still required?
 		project.frames = project.frames  # to call frames_changed
 
 	canvas.update()

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -259,12 +259,14 @@ func undo_or_redo(
 			cursor_position_label.text = "[%s×%s]" % [project.size.x, project.size.y]
 
 	elif "Frame" in action_name:
-		# TODO R2: Does what this comment says after the refacotr remain true?
+		# TODO R4: This should be safe to remove after adding play_forwards/backwards.pressed = false to _on_AnimationTimer_timeout
+		#			If not, does what this comment says after the refacotr remain true?
 		# This actually means that frames.size is one, but it hasn't been updated yet
-		if (undo and project.frames.size() == 2) or project.frames.size() == 1:  # Stop animating
-			play_forward.pressed = false
-			play_backwards.pressed = false
-			animation_timer.stop()
+#		if (undo and project.frames.size() == 2) or project.frames.size() == 1:  # Stop animating
+#			play_forward.pressed = false
+#			play_backwards.pressed = false
+#			animation_timer.stop()
+		pass
 
 	elif "Move Cels" == action_name:
 		# TODO R3: is this still required? (Looks safe to remove, unless something is added back to frames_changed)

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -255,7 +255,7 @@ func undo_or_redo(
 			cursor_position_label.text = "[%s×%s]" % [project.size.x, project.size.y]
 
 	elif "Frame" in action_name:
-		# TODO R: Does what this comment says after the refacotr remain true?
+		# TODO R: Does what this comment says after the refacotr remain true? (Perhaps this should be moved to move_frame?)
 		# This actually means that frames.size is one, but it hasn't been updated yet
 		if (undo and project.frames.size() == 2) or project.frames.size() == 1:  # Stop animating
 			play_forward.pressed = false

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -259,7 +259,7 @@ func undo_or_redo(
 			cursor_position_label.text = "[%s×%s]" % [project.size.x, project.size.y]
 
 	elif "Frame" in action_name:
-		# TODO R2: Does what this comment says after the refacotr remain true? (Perhaps this should be moved to move_frame?)
+		# TODO R2: Does what this comment says after the refacotr remain true?
 		# This actually means that frames.size is one, but it hasn't been updated yet
 		if (undo and project.frames.size() == 2) or project.frames.size() == 1:  # Stop animating
 			play_forward.pressed = false
@@ -267,7 +267,7 @@ func undo_or_redo(
 			animation_timer.stop()
 
 	elif "Move Cels" == action_name:
-		# TODO R2: is this still required?
+		# TODO R3: is this still required? (Looks safe to remove, unless something is added back to frames_changed)
 		project.frames = project.frames  # to call frames_changed
 
 	canvas.update()

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -263,6 +263,7 @@ func undo_or_redo(
 			animation_timer.stop()
 
 	elif "Move Cels" == action_name:
+		# TODO: is this still required?
 		project.frames = project.frames  # to call frames_changed
 
 	canvas.update()

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -103,6 +103,10 @@ var palettes := {}
 
 # Nodes
 var notification_label_node: PackedScene = preload("res://src/UI/NotificationLabel.tscn")
+var pixel_layer_button_node: PackedScene = preload("res://src/UI/Timeline/PixelLayerButton.tscn")
+var group_layer_button_node: PackedScene = preload("res://src/UI/Timeline/GroupLayerButton.tscn")
+var pixel_cel_button_node: PackedScene = preload("res://src/UI/Timeline/PixelCelButton.tscn")
+var group_cel_button_node: PackedScene = preload("res://src/UI/Timeline/GroupCelButton.tscn")
 
 onready var control: Node = get_tree().get_root().get_node("Control")
 

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -233,7 +233,7 @@ func undo_or_redo(
 			"Unlink Cel"
 		]
 	):
-		# TODO: Check this: THIS IS PROBABLY WRONG (can't check if GROUP LAYER if INDEX is -1)
+		# TODO H: Check this: THIS IS PROBABLY WRONG (can't check if GROUP LAYER if INDEX is -1)
 		if not current_project.layers[layer_index] is GroupLayer:
 			if layer_index > -1 and frame_index > -1:
 				canvas.update_texture(layer_index, frame_index, project)
@@ -246,7 +246,7 @@ func undo_or_redo(
 		if action_name == "Scale":
 			for i in project.frames.size():
 				for j in project.layers.size():
-					# TODO: ensure this is the correct cel type:
+					# TODO H: ensure this is the correct cel type:
 					var current_cel: BaseCel = project.frames[i].cels[j]
 					current_cel.image_texture.create_from_image(current_cel.image, 0)
 			canvas.camera_zoom()
@@ -255,7 +255,7 @@ func undo_or_redo(
 			cursor_position_label.text = "[%s×%s]" % [project.size.x, project.size.y]
 
 	elif "Frame" in action_name:
-		# TODO: Does what this comment says after the refacotr remain true?
+		# TODO R: Does what this comment says after the refacotr remain true?
 		# This actually means that frames.size is one, but it hasn't been updated yet
 		if (undo and project.frames.size() == 2) or project.frames.size() == 1:  # Stop animating
 			play_forward.pressed = false
@@ -263,7 +263,7 @@ func undo_or_redo(
 			animation_timer.stop()
 
 	elif "Move Cels" == action_name:
-		# TODO: is this still required?
+		# TODO R: is this still required?
 		project.frames = project.frames  # to call frames_changed
 
 	canvas.update()

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -258,20 +258,6 @@ func undo_or_redo(
 			canvas.pixel_grid.update()
 			cursor_position_label.text = "[%s×%s]" % [project.size.x, project.size.y]
 
-	elif "Frame" in action_name:
-		# TODO R4: This should be safe to remove after adding play_forwards/backwards.pressed = false to _on_AnimationTimer_timeout
-		#			If not, does what this comment says after the refacotr remain true?
-		# This actually means that frames.size is one, but it hasn't been updated yet
-#		if (undo and project.frames.size() == 2) or project.frames.size() == 1:  # Stop animating
-#			play_forward.pressed = false
-#			play_backwards.pressed = false
-#			animation_timer.stop()
-		pass
-
-	elif "Move Cels" == action_name:
-		# TODO R4: is this still required? (Looks safe to remove, unless something is added back to frames_changed)
-		project.frames = project.frames  # to call frames_changed
-
 	canvas.update()
 	if !project.has_changed:
 		project.has_changed = true

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -255,6 +255,7 @@ func undo_or_redo(
 			cursor_position_label.text = "[%s×%s]" % [project.size.x, project.size.y]
 
 	elif "Frame" in action_name:
+		# TODO: Does what this comment says after the refacotr remain true?
 		# This actually means that frames.size is one, but it hasn't been updated yet
 		if (undo and project.frames.size() == 2) or project.frames.size() == 1:  # Stop animating
 			play_forward.pressed = false

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -269,7 +269,7 @@ func undo_or_redo(
 		pass
 
 	elif "Move Cels" == action_name:
-		# TODO R3: is this still required? (Looks safe to remove, unless something is added back to frames_changed)
+		# TODO R4: is this still required? (Looks safe to remove, unless something is added back to frames_changed)
 		project.frames = project.frames  # to call frames_changed
 
 	canvas.update()

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -22,7 +22,6 @@ var current_project_index := 0 setget _project_changed
 var ui_tooltips := {}
 
 # Canvas related stuff
-var layers_changed_skip := false
 var can_draw := false
 var move_guides_on_canvas := false
 var has_focus := false

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -122,14 +122,16 @@ func open_pxo_file(path: String, untitled_backup: bool = false, replace_empty: b
 				Brushes.add_project_brush(image)
 
 	file.close()
-	if !empty_project:
-		Global.projects.append(new_project)
-		Global.tabs.current_tab = Global.tabs.get_tab_count() - 1
-	else:
+	if empty_project:
 		if dict.error == OK and dict.result.has("fps"):
 			Global.animation_timeline.fps_spinbox.value = dict.result.fps
+		Global.animation_timeline.project_changed()
+		# TODO: Do these need to be here?
 		new_project.frames = new_project.frames  # Just to call frames_changed
 		new_project.layers = new_project.layers  # Just to call layers_changed
+	else:
+		Global.projects.append(new_project)
+		Global.tabs.current_tab = Global.tabs.get_tab_count() - 1
 	Global.canvas.camera_zoom()
 
 	if not untitled_backup:

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -126,7 +126,7 @@ func open_pxo_file(path: String, untitled_backup: bool = false, replace_empty: b
 		if dict.error == OK and dict.result.has("fps"):
 			Global.animation_timeline.fps_spinbox.value = dict.result.fps
 		Global.animation_timeline.project_changed()
-		# TODO R: Do these need to be here?
+		# TODO R3: Do these need to be here? (Consider the bug where new project doesn't set the hidden frame buttons in frames_changed)
 		new_project.frames = new_project.frames  # Just to call frames_changed
 		new_project.layers = new_project.layers  # Just to call layers_changed
 	else:

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -126,7 +126,7 @@ func open_pxo_file(path: String, untitled_backup: bool = false, replace_empty: b
 		if dict.error == OK and dict.result.has("fps"):
 			Global.animation_timeline.fps_spinbox.value = dict.result.fps
 		Global.animation_timeline.project_changed()
-		# TODO R3: Do these need to be here? (Consider the bug where new project doesn't set the hidden frame buttons in frames_changed)
+		# TODO R4: Do these need to be here? (Consider the bug where new project doesn't set the hidden frame buttons in frames_changed)
 		new_project.frames = new_project.frames  # Just to call frames_changed
 		new_project.layers = new_project.layers  # Just to call layers_changed
 	else:

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -126,7 +126,7 @@ func open_pxo_file(path: String, untitled_backup: bool = false, replace_empty: b
 		if dict.error == OK and dict.result.has("fps"):
 			Global.animation_timeline.fps_spinbox.value = dict.result.fps
 		Global.animation_timeline.project_changed()
-		# TODO: Do these need to be here?
+		# TODO R: Do these need to be here?
 		new_project.frames = new_project.frames  # Just to call frames_changed
 		new_project.layers = new_project.layers  # Just to call layers_changed
 	else:

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -126,9 +126,6 @@ func open_pxo_file(path: String, untitled_backup: bool = false, replace_empty: b
 		if dict.error == OK and dict.result.has("fps"):
 			Global.animation_timeline.fps_spinbox.value = dict.result.fps
 		Global.animation_timeline.project_changed()
-		# TODO R4: Do these need to be here? (Consider the bug where new project doesn't set the hidden frame buttons in frames_changed)
-		new_project.frames = new_project.frames  # Just to call frames_changed
-		new_project.layers = new_project.layers  # Just to call layers_changed
 	else:
 		Global.projects.append(new_project)
 		Global.tabs.current_tab = Global.tabs.get_tab_count() - 1

--- a/src/Classes/BaseCel.gd
+++ b/src/Classes/BaseCel.gd
@@ -29,5 +29,5 @@ func copy() -> BaseCel:
 	return null
 
 
-func create_cel_button() -> Button:
+func create_cel_button() -> Node:
 	return null

--- a/src/Classes/BaseCel.gd
+++ b/src/Classes/BaseCel.gd
@@ -8,7 +8,7 @@ var opacity: float
 
 # Functions to override:
 
-# TODO: Should this be the case?
+# TODO H: Should this be the case?
 # Each Cel type should have a get_image function, which will either return
 # its image data for PixelCels, or return a render of that cel. It's meant
 # for read-only usage of image data from any type of cel

--- a/src/Classes/BaseCel.gd
+++ b/src/Classes/BaseCel.gd
@@ -25,9 +25,5 @@ func load_image_data_from_pxo(_file: File, _project_size: Vector2) -> void:
 	return
 
 
-func copy() -> BaseCel:
-	return null
-
-
 func create_cel_button() -> Node:
 	return null

--- a/src/Classes/BaseCel.gd
+++ b/src/Classes/BaseCel.gd
@@ -25,5 +25,9 @@ func load_image_data_from_pxo(_file: File, _project_size: Vector2) -> void:
 	return
 
 
+func copy() -> BaseCel:
+	return null
+
+
 func create_cel_button() -> Button:
 	return null

--- a/src/Classes/BaseCel.gd
+++ b/src/Classes/BaseCel.gd
@@ -13,9 +13,17 @@ var opacity: float
 # its image data for PixelCels, or return a render of that cel. It's meant
 # for read-only usage of image data from any type of cel
 
+func get_image() -> Image:
+	return null
+
+
 func save_image_data_to_pxo(_file: File) -> void:
 	return
 
 
 func load_image_data_from_pxo(_file: File, _project_size: Vector2) -> void:
 	return
+
+
+func create_cel_button() -> Button:
+	return null

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -97,7 +97,7 @@ func copy() -> BaseLayer:
 	copy.deserialize(serialize())
 	return copy
 
-
+# TODO R3: Would linked be be better than new_content? (Have to reverse the branches of course)
 func copy_cel(_frame: int, _new_content: bool) -> BaseCel:
 	return null
 

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -102,7 +102,7 @@ func copy() -> BaseLayer:
 func copy_cel(_frame: int, _linked: bool) -> BaseCel:
 	return null
 
-# Used to copy all cels with cel linking properly set up between copies:
+# Used to copy all cels with cel linking properly set up between this set of copies:
 func copy_all_cels() -> Array:
 	return []
 

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -97,6 +97,16 @@ func copy() -> BaseLayer:
 	copy.deserialize(serialize())
 	return copy
 
+
+func copy_cel(_frame: int, _new_content: bool) -> BaseCel:
+	return null
+
+# TODO R3: Currently new content is never needed to be false, should it be removed?
+# Used to copy all cels with cel linking properly set up between copies:
+func copy_all_cels(_new_content: bool) -> Array:
+	return []
+
+
 # TODO L: Should this be turned into set_as_default_name?
 func get_default_name(number: int) -> String:
 	return tr("Layer") + " %s" % number

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -87,6 +87,14 @@ func deserialize(dict: Dictionary) -> void:
 		parent = project.layers[dict.parent]
 
 
+func copy() -> BaseLayer:
+	var copy = get_script().new()
+	copy.project = project
+	copy.index = index
+	copy.deserialize(serialize())
+	return copy
+
+
 func get_default_name(number: int) -> String:
 	return tr("Layer") + " %s" % number
 

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -21,7 +21,8 @@ func is_a_parent_of(layer: BaseLayer) -> bool:
 		return is_a_parent_of(layer.parent)
 	return false
 
-# TODO L: Consider going backwards in get_children functions, to allow breaking
+# TODO L: Consider going backwards in get_children functions, to allow breaking (test performance)
+# TODO L: Consider combining these into one func with bool, and adding a get_child_count func
 func get_children_direct() -> Array:
 	var children := []
 	for i in range(index):

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -97,13 +97,12 @@ func copy() -> BaseLayer:
 	copy.deserialize(serialize())
 	return copy
 
-# TODO R3: Would linked be be better than new_content? (Have to reverse the branches of course)
-func copy_cel(_frame: int, _new_content: bool) -> BaseCel:
+
+func copy_cel(_frame: int, _linked: bool) -> BaseCel:
 	return null
 
-# TODO R3: Currently new content is never needed to be false, should it be removed?
 # Used to copy all cels with cel linking properly set up between copies:
-func copy_all_cels(_new_content: bool) -> Array:
+func copy_all_cels() -> Array:
 	return []
 
 

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -108,3 +108,7 @@ func can_layer_get_drawn() -> bool:
 
 func accepts_child(_layer: BaseLayer) -> bool:
 	return false
+
+
+func create_layer_button() -> Node:
+	return null

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -107,9 +107,8 @@ func copy_all_cels(_new_content: bool) -> Array:
 	return []
 
 
-# TODO L: Should this be turned into set_as_default_name?
-func get_default_name(number: int) -> String:
-	return tr("Layer") + " %s" % number
+func set_name_to_default(number: int) -> void:
+	name = tr("Layer") + " %s" % number
 
 
 func can_layer_get_drawn() -> bool:

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -18,7 +18,7 @@ func is_a_parent_of(layer: BaseLayer) -> bool:
 		return is_a_parent_of(layer.parent)
 	return false
 
-# TODO: Consider going backwards in get_children functions, to allow breaking
+# TODO L: Consider going backwards in get_children functions, to allow breaking
 func get_children_direct() -> Array:
 	var children := []
 	for i in range(index):
@@ -46,7 +46,7 @@ func is_expanded_in_hierarchy() -> bool:
 		return parent.expanded and parent.is_expanded_in_hierarchy()
 	return true
 
-# TODO: Search for layer visbility/locked checks that should be changed to the hierarchy ones:
+# TODO H: Search for layer visbility/locked checks that should be changed to the hierarchy ones:
 func is_visible_in_hierarchy() -> bool:
 	if is_instance_valid(parent) and visible:
 		return parent.is_visible_in_hierarchy()
@@ -68,7 +68,7 @@ func get_hierarchy_depth() -> int:
 # Functions to Override:
 
 func serialize() -> Dictionary:
-	assert(index == project.layers.find(self)) # TODO: remove once sure index is synced properly
+	assert(index == project.layers.find(self)) # TODO H: remove once sure index is synced properly
 	return {
 		"name": name,
 		"visible": visible,

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -7,6 +7,9 @@ var visible := true
 var locked := false
 var blend_mode := 0
 var parent: BaseLayer
+# TODO H: Memory seems to not be freed when closing a project. I suspect this new project ref to
+#		be the reason (in Project.remove simply removing the project from the Global.projects array
+#		can't auto free it because there's still refences to it, in the layers):
 var project
 var index: int
 

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -40,6 +40,12 @@ func has_children() -> bool:
 		return false
 	return project.layers[index - 1].parent == self
 
+
+func is_expanded_in_hierarchy() -> bool:
+	if is_instance_valid(parent):
+		return parent.expanded and parent.is_expanded_in_hierarchy()
+	return true
+
 # TODO: Search for layer visbility/locked checks that should be changed to the hierarchy ones:
 func is_visible_in_hierarchy() -> bool:
 	if is_instance_valid(parent) and visible:

--- a/src/Classes/BaseLayer.gd
+++ b/src/Classes/BaseLayer.gd
@@ -97,7 +97,7 @@ func copy() -> BaseLayer:
 	copy.deserialize(serialize())
 	return copy
 
-
+# TODO L: Should this be turned into set_as_default_name?
 func get_default_name(number: int) -> String:
 	return tr("Layer") + " %s" % number
 

--- a/src/Classes/GroupCel.gd
+++ b/src/Classes/GroupCel.gd
@@ -10,3 +10,7 @@ func _init(_opacity := 1.0) -> void:
 func get_image() -> Image:
 	# TODO: render the material as an image and return it
 	return Image.new()
+
+
+func create_cel_button() -> Button:
+	return load("res://src/UI/Timeline/GroupCelButton.tscn").instance() as Button

--- a/src/Classes/GroupCel.gd
+++ b/src/Classes/GroupCel.gd
@@ -12,5 +12,10 @@ func get_image() -> Image:
 	return Image.new()
 
 
+func copy() -> BaseCel:
+	# Using get_script over the class name prevents a cyclic reference:
+	return get_script().new(opacity)
+
+
 func create_cel_button() -> Button:
 	return load("res://src/UI/Timeline/GroupCelButton.tscn").instance() as Button

--- a/src/Classes/GroupCel.gd
+++ b/src/Classes/GroupCel.gd
@@ -17,5 +17,5 @@ func copy() -> BaseCel:
 	return get_script().new(opacity)
 
 
-func create_cel_button() -> Button:
-	return load("res://src/UI/Timeline/GroupCelButton.tscn").instance() as Button
+func create_cel_button() -> Node:
+	return Global.group_cel_button_node.instance()

--- a/src/Classes/GroupCel.gd
+++ b/src/Classes/GroupCel.gd
@@ -8,7 +8,7 @@ func _init(_opacity := 1.0) -> void:
 
 
 func get_image() -> Image:
-	# TODO: render the material as an image and return it
+	# TODO H: render the material as an image and return it
 	return Image.new()
 
 

--- a/src/Classes/GroupCel.gd
+++ b/src/Classes/GroupCel.gd
@@ -12,10 +12,5 @@ func get_image() -> Image:
 	return Image.new()
 
 
-func copy() -> BaseCel:
-	# Using get_script over the class name prevents a cyclic reference:
-	return get_script().new(opacity)
-
-
 func create_cel_button() -> Node:
 	return Global.group_cel_button_node.instance()

--- a/src/Classes/GroupLayer.gd
+++ b/src/Classes/GroupLayer.gd
@@ -21,6 +21,19 @@ func deserialize(dict: Dictionary) -> void:
 	expanded = dict.expanded
 
 
+func copy_cel(frame_index: int, _new_content: bool) -> BaseCel:
+	var cel: GroupCel = project.frames[frame_index].cels[index]
+	return GroupCel.new(cel.opacity)
+
+
+func copy_all_cels(_new_content: bool) -> Array:
+	var cels := []
+	for frame in project.frames:
+		var cel: GroupCel = frame.cels[index]
+		cels.append(GroupCel.new(cel.opacity))
+	return cels
+
+
 func get_default_name(number: int) -> String:
 	return tr("Group") + " %s" % number
 

--- a/src/Classes/GroupLayer.gd
+++ b/src/Classes/GroupLayer.gd
@@ -34,8 +34,8 @@ func copy_all_cels(_new_content: bool) -> Array:
 	return cels
 
 
-func get_default_name(number: int) -> String:
-	return tr("Group") + " %s" % number
+func set_name_to_default(number: int) -> void:
+	name = tr("Group") + " %s" % number
 
 
 func accepts_child(_layer: BaseLayer) -> bool:

--- a/src/Classes/GroupLayer.gd
+++ b/src/Classes/GroupLayer.gd
@@ -7,13 +7,6 @@ var expanded := true
 func _init(_name := "") -> void:
 	name = _name
 
-
-func is_expanded_in_hierarchy() -> bool:
-	if is_instance_valid(parent) and expanded:
-		return parent.is_expanded_in_hierarchy()
-	return expanded
-
-
 # Overridden Functions:
 
 func serialize() -> Dictionary:

--- a/src/Classes/GroupLayer.gd
+++ b/src/Classes/GroupLayer.gd
@@ -27,3 +27,7 @@ func get_default_name(number: int) -> String:
 
 func accepts_child(_layer: BaseLayer) -> bool:
 	return true
+
+
+func create_layer_button() -> Node:
+	return Global.group_layer_button_node.instance()

--- a/src/Classes/GroupLayer.gd
+++ b/src/Classes/GroupLayer.gd
@@ -21,12 +21,12 @@ func deserialize(dict: Dictionary) -> void:
 	expanded = dict.expanded
 
 
-func copy_cel(frame_index: int, _new_content: bool) -> BaseCel:
+func copy_cel(frame_index: int, _linked: bool) -> BaseCel:
 	var cel: GroupCel = project.frames[frame_index].cels[index]
 	return GroupCel.new(cel.opacity)
 
 
-func copy_all_cels(_new_content: bool) -> Array:
+func copy_all_cels() -> Array:
 	var cels := []
 	for frame in project.frames:
 		var cel: GroupCel = frame.cels[index]

--- a/src/Classes/PixelCel.gd
+++ b/src/Classes/PixelCel.gd
@@ -35,7 +35,10 @@ func load_image_data_from_pxo(file: File, project_size: Vector2) -> void:
 	image.create_from_data(project_size.x, project_size.y, false, Image.FORMAT_RGBA8, buffer)
 	image_changed(image)
 
-
+# TODO R3: A copy_image bool parameter could be useful for places such as the merging layers function
+# 		where the copied cels don't need the image to be copied (at least not yet in that case)
+#		Alternatively, keep it as is, and maybe put a comment on the copy function mentioning that it
+# 		copies the image data too...
 func copy() -> BaseCel:
 	var copy_image := Image.new()
 	copy_image.copy_from(image)

--- a/src/Classes/PixelCel.gd
+++ b/src/Classes/PixelCel.gd
@@ -37,6 +37,15 @@ func load_image_data_from_pxo(file: File, project_size: Vector2) -> void:
 	image_changed(image)
 
 
+func copy() -> BaseCel:
+	var copy_image := Image.new()
+	copy_image.copy_from(image)
+	var copy_texture := ImageTexture.new()
+	copy_texture.create_from_image(copy_image, 0)
+	# Using get_script over the class name prevents a cyclic reference:
+	return get_script().new(copy_image, opacity, copy_texture)
+
+
 func create_cel_button() -> Button:
 	var cel_button = load("res://src/UI/Timeline/PixelCelButton.tscn").instance()
 	cel_button.get_child(0).texture = image_texture

--- a/src/Classes/PixelCel.gd
+++ b/src/Classes/PixelCel.gd
@@ -35,3 +35,9 @@ func load_image_data_from_pxo(file: File, project_size: Vector2) -> void:
 	var buffer := file.get_buffer(project_size.x * project_size.y * 4)
 	image.create_from_data(project_size.x, project_size.y, false, Image.FORMAT_RGBA8, buffer)
 	image_changed(image)
+
+
+func create_cel_button() -> Button:
+	var cel_button = load("res://src/UI/Timeline/PixelCelButton.tscn").instance()
+	cel_button.get_child(0).texture = image_texture
+	return cel_button

--- a/src/Classes/PixelCel.gd
+++ b/src/Classes/PixelCel.gd
@@ -12,7 +12,7 @@ func _init(_image := Image.new(), _opacity := 1.0, _image_texture: ImageTexture 
 		image_texture = _image_texture
 	else:
 		image_texture = ImageTexture.new()
-	self.image = _image
+	self.image = _image # Set image and call setter
 	opacity = _opacity
 
 
@@ -34,18 +34,6 @@ func load_image_data_from_pxo(file: File, project_size: Vector2) -> void:
 	var buffer := file.get_buffer(project_size.x * project_size.y * 4)
 	image.create_from_data(project_size.x, project_size.y, false, Image.FORMAT_RGBA8, buffer)
 	image_changed(image)
-
-# TODO R3: A copy_image bool parameter could be useful for places such as the merging layers function
-# 		where the copied cels don't need the image to be copied (at least not yet in that case)
-#		Alternatively, keep it as is, and maybe put a comment on the copy function mentioning that it
-# 		copies the image data too...
-func copy() -> BaseCel:
-	var copy_image := Image.new()
-	copy_image.copy_from(image)
-	var copy_texture := ImageTexture.new()
-	copy_texture.create_from_image(copy_image, 0)
-	# Using get_script over the class name prevents a cyclic reference:
-	return get_script().new(copy_image, opacity, copy_texture)
 
 
 func create_cel_button() -> Node:

--- a/src/Classes/PixelCel.gd
+++ b/src/Classes/PixelCel.gd
@@ -7,7 +7,6 @@ extends BaseCel
 var image: Image setget image_changed
 var image_texture: ImageTexture
 
-
 func _init(_image := Image.new(), _opacity := 1.0, _image_texture: ImageTexture = null) -> void:
 	if _image_texture:
 		image_texture = _image_texture
@@ -46,7 +45,7 @@ func copy() -> BaseCel:
 	return get_script().new(copy_image, opacity, copy_texture)
 
 
-func create_cel_button() -> Button:
-	var cel_button = load("res://src/UI/Timeline/PixelCelButton.tscn").instance()
+func create_cel_button() -> Node:
+	var cel_button = Global.pixel_cel_button_node.instance()
 	cel_button.get_child(0).texture = image_texture
 	return cel_button

--- a/src/Classes/PixelLayer.gd
+++ b/src/Classes/PixelLayer.gd
@@ -4,7 +4,7 @@ extends BaseLayer
 
 var new_cels_linked := false
 var linked_cels := []  # Array of Frames
-
+# TODO: Should _init include project as a parameter? (for all Layer types)
 func _init(_name := "") -> void:
 	name = _name
 

--- a/src/Classes/PixelLayer.gd
+++ b/src/Classes/PixelLayer.gd
@@ -32,6 +32,44 @@ func deserialize(dict: Dictionary) -> void:
 		linked_cel.image_texture = linked_cels[0].cels[index].image_texture
 
 
+func copy_cel(frame_index: int, new_content: bool) -> BaseCel:
+	var cel: PixelCel = project.frames[frame_index].cels[index]
+	if new_content:
+		var copy_image := Image.new()
+		copy_image.copy_from(cel.image)
+		return PixelCel.new(copy_image, cel.opacity)
+	else:
+		return PixelCel.new(cel.image, cel.opacity, cel.image_texture)
+
+
+func copy_all_cels(new_content: bool) -> Array:
+	var cels := []
+
+	var linked_image: Image
+	var linked_texture: ImageTexture
+	if not linked_cels.empty():
+		var cel: PixelCel = linked_cels[0].cels[index]
+		if new_content:
+			linked_image = Image.new()
+			linked_image.copy_from(cel.image)
+			linked_texture = ImageTexture.new()
+		else:
+			linked_image = cel.image
+			linked_texture = cel.image_texture
+
+	for frame in project.frames:
+		var cel: PixelCel = frame.cels[index]
+		if linked_cels.has(frame):
+			cels.append(PixelCel.new(linked_image, cel.opacity, linked_texture))
+		elif new_content:
+			var copy_image := Image.new()
+			copy_image.copy_from(cel.image)
+			cels.append(PixelCel.new(copy_image, cel.opacity))
+		else:
+			cels.append(PixelCel.new(cel.image, cel.opacity, cel.image_texture))
+	return cels
+
+
 func can_layer_get_drawn() -> bool:
 	return is_visible_in_hierarchy() && !is_locked_in_hierarchy()
 

--- a/src/Classes/PixelLayer.gd
+++ b/src/Classes/PixelLayer.gd
@@ -4,7 +4,7 @@ extends BaseLayer
 
 var new_cels_linked := false
 var linked_cels := []  # Array of Frames
-# TODO: Should _init include project as a parameter? (for all Layer types)
+# TODO H: Should _init include project as a parameter? (for all Layer types)
 func _init(_name := "") -> void:
 	name = _name
 

--- a/src/Classes/PixelLayer.gd
+++ b/src/Classes/PixelLayer.gd
@@ -33,10 +33,11 @@ func deserialize(dict: Dictionary) -> void:
 
 
 func copy_cel(frame_index: int, linked: bool) -> BaseCel:
-	var cel: PixelCel = project.frames[frame_index].cels[index]
-	if linked:
+	if linked and not linked_cels.empty():
+		var cel: PixelCel = linked_cels[0].cels[index]
 		return PixelCel.new(cel.image, cel.opacity, cel.image_texture)
 	else:
+		var cel: PixelCel = project.frames[frame_index].cels[index]
 		var copy_image := Image.new()
 		copy_image.copy_from(cel.image)
 		return PixelCel.new(copy_image, cel.opacity)

--- a/src/Classes/PixelLayer.gd
+++ b/src/Classes/PixelLayer.gd
@@ -34,3 +34,7 @@ func deserialize(dict: Dictionary) -> void:
 
 func can_layer_get_drawn() -> bool:
 	return is_visible_in_hierarchy() && !is_locked_in_hierarchy()
+
+
+func create_layer_button() -> Node:
+	return Global.pixel_layer_button_node.instance()

--- a/src/Classes/PixelLayer.gd
+++ b/src/Classes/PixelLayer.gd
@@ -32,41 +32,35 @@ func deserialize(dict: Dictionary) -> void:
 		linked_cel.image_texture = linked_cels[0].cels[index].image_texture
 
 
-func copy_cel(frame_index: int, new_content: bool) -> BaseCel:
+func copy_cel(frame_index: int, linked: bool) -> BaseCel:
 	var cel: PixelCel = project.frames[frame_index].cels[index]
-	if new_content:
+	if linked:
+		return PixelCel.new(cel.image, cel.opacity, cel.image_texture)
+	else:
 		var copy_image := Image.new()
 		copy_image.copy_from(cel.image)
 		return PixelCel.new(copy_image, cel.opacity)
-	else:
-		return PixelCel.new(cel.image, cel.opacity, cel.image_texture)
 
 
-func copy_all_cels(new_content: bool) -> Array:
+func copy_all_cels() -> Array:
 	var cels := []
 
 	var linked_image: Image
 	var linked_texture: ImageTexture
 	if not linked_cels.empty():
 		var cel: PixelCel = linked_cels[0].cels[index]
-		if new_content:
-			linked_image = Image.new()
-			linked_image.copy_from(cel.image)
-			linked_texture = ImageTexture.new()
-		else:
-			linked_image = cel.image
-			linked_texture = cel.image_texture
+		linked_image = Image.new()
+		linked_image.copy_from(cel.image)
+		linked_texture = ImageTexture.new()
 
 	for frame in project.frames:
 		var cel: PixelCel = frame.cels[index]
 		if linked_cels.has(frame):
 			cels.append(PixelCel.new(linked_image, cel.opacity, linked_texture))
-		elif new_content:
+		else:
 			var copy_image := Image.new()
 			copy_image.copy_from(cel.image)
 			cels.append(PixelCel.new(copy_image, cel.opacity))
-		else:
-			cels.append(PixelCel.new(cel.image, cel.opacity, cel.image_texture))
 	return cels
 
 

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -565,6 +565,7 @@ func _set_timeline_first_and_last_frames() -> void:
 	# when the play buttons get pressed anyway
 	Global.animation_timeline.first_frame = 0
 	Global.animation_timeline.last_frame = frames.size() - 1
+	# TODO NOTE: Perhaps its needed fo the play_only_tags bit?
 	if Global.play_only_tags:
 		for tag in animation_tags:
 			if current_frame + 1 >= tag.from && current_frame + 1 <= tag.to:
@@ -795,6 +796,7 @@ func add_frames(new_frames: Array, indices: Array) -> void:  # indices should be
 		for f in range(frames.size()):
 			layer_cel_container.get_child(f).frame = f
 			layer_cel_container.get_child(f).button_setup()
+	_set_timeline_first_and_last_frames()
 
 
 func remove_frames(indices: Array) -> void:  # indices should be in ascending order
@@ -815,6 +817,7 @@ func remove_frames(indices: Array) -> void:  # indices should be in ascending or
 		for f in range(frames.size()):
 			layer_cel_container.get_child(f).frame = f
 			layer_cel_container.get_child(f).button_setup()
+	_set_timeline_first_and_last_frames()
 
 
 func move_frame(from_index: int, to_index: int) -> void:
@@ -835,6 +838,7 @@ func move_frame(from_index: int, to_index: int) -> void:
 		for f in range(frames.size()):
 			layer_cel_container.get_child(f).frame = f
 			layer_cel_container.get_child(f).button_setup()
+	_set_timeline_first_and_last_frames()
 
 
 func swap_frame(a_index: int, b_index: int) -> void:
@@ -847,6 +851,7 @@ func swap_frame(a_index: int, b_index: int) -> void:
 	Global.animation_timeline.project_frame_added(a_index)
 	Global.animation_timeline.project_frame_removed(b_index)
 	Global.animation_timeline.project_frame_added(b_index)
+	_set_timeline_first_and_last_frames()
 
 
 func add_layers(new_layers: Array, indices: Array, cels: Array) -> void:  # cels is 2d Array of cels

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -396,7 +396,17 @@ func _size_changed(value: Vector2) -> void:
 func _frames_changed(value: Array) -> void:
 	Global.canvas.selection.transform_content_confirm()
 	frames = value
-#	selected_cels.clear() # TODO R2: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
+#	selected_cels.clear() # TODO R4: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
+	# TODO NOTE: perhaps if you don't clear the selected cels, some invalid ones may be included? (ie: removed cels?)
+	# 			selected cels is already cleared when using the new frame/layer/cel functions
+	#			THESE SHOULD PROBABLY BE SAFE TO REMOVE FOR NORMAL USAGE, IS THERE A PLACE WHERE THEY'RE NOT?
+	#			OTHER THAN ON STARTUP, IS THERE ANY DISADVANGTAGE TO KEEPING? (may be better to keep just to be sure)
+	print(selected_cels)
+	for c in selected_cels:
+		if c[0] >= frames.size():
+			print("invalid frame in selected cel")
+	# REMOVE ALL THAT DEBUG CODE ^^^^^^^^^^^^^^^^
+
 	_set_timeline_first_and_last_frames()
 
 
@@ -406,8 +416,17 @@ func _layers_changed(value: Array) -> void:
 		Global.layers_changed_skip = false
 		return
 
-#	selected_cels.clear() # TODO R2: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
-	# TODO R2: investigate wether these are still required:
+#	selected_cels.clear() # TODO R4: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
+	# TODO NOTE: perhaps if you don't clear the selected cels, some invalid ones may be included? (ie: removed cels?)
+	# 			selected cels is already cleared when using the new frame/layer/cel functions
+	#			THESE SHOULD PROBABLY BE SAFE TO REMOVE FOR NORMAL USAGE, IS THERE A PLACE WHERE THEY'RE NOT?
+	#			OTHER THAN ON STARTUP, IS THERE ANY DISADVANGTAGE TO KEEPING? (may be better to keep just to be sure)
+	for c in selected_cels:
+		if c[1] >= layers.size():
+			print("invalid layer in selected cel")
+	# REMOVE ALL THAT DEBUG CODE ^^^^^^^^^^^^^^^^
+
+	# TODO R4: investigate wether these are still required (Should be safe to remove):
 #	var layer_button = Global.layers_container.get_child(
 #		Global.layers_container.get_child_count() - 1 - current_layer
 #	)

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -584,13 +584,14 @@ func is_empty() -> bool:
 
 
 func duplicate_layers() -> Array:
-	# TODO R1: May want to test this a bit after refactor
-	# TODO H: When duplicating the layers, parent references would be using the old layers now, this will probably cause bugs
 	var new_layers: Array = layers.duplicate()
 	# Loop through the array to create new classes for each element, so that they
 	# won't be the same as the original array's classes. Needed for undo/redo to work properly.
 	for i in new_layers.size():
 		new_layers[i] = new_layers[i].copy()
+	for l in new_layers:
+		if is_instance_valid(l.parent):
+			l.parent = new_layers[l.parent.index] # Update the parent to the new copy of the parent
 	return new_layers
 
 

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -462,11 +462,9 @@ func _frame_changed(value: int) -> void:
 	)
 
 	if current_frame < frames.size():
-		# TODO H: Make this work with groups:
-		if not layers[current_layer] is GroupLayer:
-			var cel_opacity: float = frames[current_frame].cels[current_layer].opacity
-			Global.layer_opacity_slider.value = cel_opacity * 100
-			Global.layer_opacity_spinbox.value = cel_opacity * 100
+		var cel_opacity: float = frames[current_frame].cels[current_layer].opacity
+		Global.layer_opacity_slider.value = cel_opacity * 100
+		Global.layer_opacity_spinbox.value = cel_opacity * 100
 
 	Global.canvas.update()
 	Global.transparent_checker.update_rect()

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -434,7 +434,7 @@ func _layers_changed(value: Array) -> void:
 #	self.current_frame = current_frame  # Call frame_changed to update UI
 	toggle_layer_buttons()
 
-
+# TODO R4: should be safe to remove
 func _remove_cel_buttons() -> void:
 	for container in Global.frames_container.get_children():
 		Global.frames_container.remove_child(container)
@@ -778,6 +778,9 @@ func resize_bitmap_values(bitmap: BitMap, new_size: Vector2, flip_x: bool, flip_
 	return new_bitmap
 
 
+# Timeline modifications
+
+
 func add_frames(new_frames: Array, indices: Array) -> void:  # indices should be in ascending order
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
@@ -1001,26 +1004,3 @@ func swap_cel(a_frame: int, a_layer: int, b_frame: int, b_layer: int) -> void:
 	Global.animation_timeline.project_cel_added(a_frame, a_layer)
 	Global.animation_timeline.project_cel_removed(b_frame, b_layer)
 	Global.animation_timeline.project_cel_added(b_frame, b_layer)
-
-
-func _update_animation_timeline_selection() -> void:
-	for cel in selected_cels:
-		var frame: int = cel[0]
-		var layer: int = cel[1]
-		if frame < Global.frame_ids.get_child_count():
-			var frame_button: BaseButton = Global.frame_ids.get_child(frame)
-			frame_button.pressed = true
-
-		var container_child_count: int = Global.frames_container.get_child_count()
-		if layer < container_child_count:
-			var container = Global.frames_container.get_child(
-				container_child_count - 1 - layer
-			)
-			if frame < container.get_child_count():
-				var cel_button = container.get_child(frame)
-				cel_button.pressed = true
-
-			var layer_button = Global.layers_container.get_child(
-				container_child_count - 1 - layer
-			)
-			layer_button.pressed = true

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -10,8 +10,8 @@ var tile_mode_rects := []  # Cached to avoid recalculation
 var undos := 0  # The number of times we added undo properties
 var fill_color := Color(0)
 var has_changed := false setget _has_changed_changed
-var frames := [] setget _frames_changed  # Array of Frames (that contain Cels)
-var layers := [] setget _layers_changed  # Array of Layers
+var frames := [] # Array of Frames (that contain Cels)
+var layers := [] # Array of Layers
 var current_frame := 0 setget _frame_changed
 var current_layer := 0 setget _layer_changed
 var selected_cels := [[0, 0]]  # Array of Arrays of 2 integers (frame & layer)
@@ -391,48 +391,6 @@ func _name_changed(value: String) -> void:
 func _size_changed(value: Vector2) -> void:
 	size = value
 	_update_tile_mode_rects()
-
-
-func _frames_changed(value: Array) -> void:
-	Global.canvas.selection.transform_content_confirm()
-	frames = value
-#	selected_cels.clear() # TODO R4: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
-	# TODO NOTE: perhaps if you don't clear the selected cels, some invalid ones may be included? (ie: removed cels?)
-	# 			selected cels is already cleared when using the new frame/layer/cel functions
-	#			THESE SHOULD PROBABLY BE SAFE TO REMOVE FOR NORMAL USAGE, IS THERE A PLACE WHERE THEY'RE NOT?
-	#			OTHER THAN ON STARTUP, IS THERE ANY DISADVANGTAGE TO KEEPING? (may be better to keep just to be sure)
-	print(selected_cels)
-	for c in selected_cels:
-		if c[0] >= frames.size():
-			print("invalid frame in selected cel")
-	# REMOVE ALL THAT DEBUG CODE ^^^^^^^^^^^^^^^^
-
-	_set_timeline_first_and_last_frames()
-
-
-func _layers_changed(value: Array) -> void:
-	layers = value
-	if Global.layers_changed_skip:
-		Global.layers_changed_skip = false
-		return
-
-#	selected_cels.clear() # TODO R4: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
-	# TODO NOTE: perhaps if you don't clear the selected cels, some invalid ones may be included? (ie: removed cels?)
-	# 			selected cels is already cleared when using the new frame/layer/cel functions
-	#			THESE SHOULD PROBABLY BE SAFE TO REMOVE FOR NORMAL USAGE, IS THERE A PLACE WHERE THEY'RE NOT?
-	#			OTHER THAN ON STARTUP, IS THERE ANY DISADVANGTAGE TO KEEPING? (may be better to keep just to be sure)
-	for c in selected_cels:
-		if c[1] >= layers.size():
-			print("invalid layer in selected cel")
-	# REMOVE ALL THAT DEBUG CODE ^^^^^^^^^^^^^^^^
-
-	# TODO R4: investigate wether these are still required (Should be safe to remove):
-#	var layer_button = Global.layers_container.get_child(
-#		Global.layers_container.get_child_count() - 1 - current_layer
-#	)
-#	layer_button.pressed = true
-#	self.current_frame = current_frame  # Call frame_changed to update UI
-	toggle_layer_buttons()
 
 
 func _frame_changed(value: int) -> void:

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -499,7 +499,10 @@ func _toggle_layer_buttons() -> void:
 		or layers.size() == child_count + 1
 	)
 	Global.disable_button(Global.move_up_layer_button, current_layer == layers.size() - 1)
-	Global.disable_button(Global.move_down_layer_button, current_layer == child_count)
+	Global.disable_button(Global.move_down_layer_button,
+		current_layer == child_count
+		and not is_instance_valid(layers[current_layer].parent)
+	)
 	Global.disable_button(Global.merge_down_layer_button,
 		current_layer == child_count
 		or layers[current_layer] is GroupLayer

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -851,6 +851,7 @@ func swap_frame(a_index: int, b_index: int) -> void:
 
 func add_layers(new_layers: Array, indices: Array, cels: Array) -> void:  # cels is 2d Array of cels
 	assert(self == Global.current_project) # TODO R3: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
+	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
 	for i in range(indices.size()):
 		layers.insert(indices[i], new_layers[i])
@@ -870,6 +871,7 @@ func add_layers(new_layers: Array, indices: Array, cels: Array) -> void:  # cels
 
 
 func remove_layers(indices: Array) -> void:
+	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
 	for i in range(indices.size()):
 		# With each removed index, future indices need to be lowered, so subtract by i
@@ -890,6 +892,7 @@ func remove_layers(indices: Array) -> void:
 
 # from_indices and to_indicies should be in ascending order
 func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> void:
+	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
 	var removed_layers := []
 	var removed_cels := [] # 2D array of cels (an array for each layer removed)
@@ -921,6 +924,7 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 # "a" and "b" should both contain "from", "to", and "to_parents" arrays.
 # (Using dictionaries because there seems to be a limit of 5 arguments for do/undo method calls)
 func swap_layers(a: Dictionary, b: Dictionary) -> void:
+	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
 	print("a: ", a, "  b: ", b) # TODO R3: Remove
 	var a_layers := []

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -779,7 +779,6 @@ func resize_bitmap_values(bitmap: BitMap, new_size: Vector2, flip_x: bool, flip_
 
 
 func add_frames(new_frames: Array, indices: Array) -> void:  # indices should be in ascending order
-	assert(self == Global.current_project) # TODO R3: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
 	for i in range(new_frames.size()):
@@ -854,7 +853,6 @@ func swap_frame(a_index: int, b_index: int) -> void:
 
 
 func add_layers(new_layers: Array, indices: Array, cels: Array) -> void:  # cels is 2d Array of cels
-	assert(self == Global.current_project) # TODO R3: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
 	for i in range(indices.size()):
@@ -930,7 +928,6 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 func swap_layers(a: Dictionary, b: Dictionary) -> void:
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
-	print("a: ", a, "  b: ", b) # TODO R3: Remove
 	var a_layers := []
 	var b_layers := []
 	var a_cels := [] # 2D array of cels (an array for each layer removed)

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -434,12 +434,6 @@ func _layers_changed(value: Array) -> void:
 #	self.current_frame = current_frame  # Call frame_changed to update UI
 	toggle_layer_buttons()
 
-# TODO R4: should be safe to remove
-func _remove_cel_buttons() -> void:
-	for container in Global.frames_container.get_children():
-		Global.frames_container.remove_child(container)
-		container.queue_free()
-
 
 func _frame_changed(value: int) -> void:
 	Global.canvas.selection.transform_content_confirm()

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -1082,20 +1082,41 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 func move_cel(from_frame: int, to_frame: int, layer: int) -> void:
 	# TODO: Current frame
 	# TODO: Current layer
+
+	# TODO: Remove this debugging chunk:
+	var OG_CELS = []
+	for F in frames:
+		OG_CELS.append(F.cels[layer])
+
 	var cel: BaseCel = frames[from_frame].cels[layer]
-	if from_frame < to_frame:
-		for f in range(from_frame + 1, to_frame + 1):
-			frames[f - 1].cels[layer] = frames[f].cels[layer]
+	if to_frame < from_frame:
+		# TODO: These cels were not always correct... verify they are:
+		# TODO: After testing for correctness, can you reduce the amoutn of +/- 1s?
+		for f in range(from_frame - 1, to_frame - 1, -1): # Backward range
+			frames[f + 1].cels[layer] = frames[f].cels[layer] # Move right
 	else:
-		for f in range(to_frame, from_frame):
-			frames[f + 1].cels[layer] = frames[f].cels[layer]
+		for f in range(from_frame + 1, to_frame + 1): # Forward range
+			frames[f - 1].cels[layer] = frames[f].cels[layer] # Move left
 	frames[to_frame].cels[layer] = cel
 	Global.animation_timeline.project_cel_removed(from_frame, layer)
 	Global.animation_timeline.project_cel_added(to_frame, layer)
+
+	# TODO: Remove this debugging chunk:
+	var TEMP_CEL_INDICES = []
+	for F in frames:
+		TEMP_CEL_INDICES.append(OG_CELS.find(F.cels[layer]))
+		assert(TEMP_CEL_INDICES.count(TEMP_CEL_INDICES[-1]) == 1)
+	print("From: ", from_frame, " To: ", to_frame)
+	print("CELS: ", TEMP_CEL_INDICES)
+
 	# Update the cel buttons for this layer:
 	var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - layer)
 	for f in range(frames.size()):
 		layer_cel_container.get_child(f).frame = f
+
+		# TODO: Remove this after the fix is verified (and remove all spacing):
+		layer_cel_container.get_child(f).cel = frames[f].cels[layer]
+
 		layer_cel_container.get_child(f).button_setup()
 
 

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -872,22 +872,21 @@ func remove_layers(indices: Array) -> void:
 # from_indices and to_indicies should be in ascending order
 func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> void:
 	selected_cels.clear()
-	var old_layers := layers.duplicate() # TODO R1: Could maybe change to just empty layers array, using append(pop_at) trick like in swap_layers
+	var removed_layers := []
 	var removed_cels := [] # 2D array of cels (an array for each layer removed)
 
-	for i in range(from_indices.size()):
+	for i in from_indices.size():
 		# With each removed index, future indices need to be lowered, so subtract by i
-		layers.remove(from_indices[i] - i)
+		removed_layers.append(layers.pop_at(from_indices[i] - i))
+		removed_layers[i].parent = to_parents[i] # parents must be set before UI created in next loop
 		removed_cels.append([])
 		for frame in frames:
 			removed_cels[i].append(frame.cels.pop_at(from_indices[i] - i))
 		Global.animation_timeline.project_layer_removed(from_indices[i] - i)
-	for i in range(to_indices.size()):
-		layers.insert(to_indices[i], old_layers[from_indices[i]])
-		layers[to_indices[i]].parent = to_parents[i] # TODO R1: it could be possible to do the to_parents when removing (previous loop), allowing this loop to be recombined with the next
+	for i in to_indices.size():
+		layers.insert(to_indices[i], removed_layers[i])
 		for f in range(frames.size()):
 			frames[f].cels.insert(to_indices[i], removed_cels[i][f])
-	for i in range(to_indices.size()): # Loop again (All parents must be set before adding the UI)
 		Global.animation_timeline.project_layer_added(to_indices[i])
 	# Update the layer indices and layer/cel buttons:
 	for l in range(layers.size()):

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -496,6 +496,10 @@ func _toggle_layer_buttons_layers() -> void:
 	if layers[current_layer].is_locked_in_hierarchy():
 		Global.disable_button(Global.remove_layer_button, true)
 
+	# TODO R0: Figure out how to disable the remove layer button when a group that has all layers as chidlren
+	#			is selected:
+	var current_layer_size = layers[current_layer].get_children_recursive().size() + 1
+
 	if layers.size() == 1:
 		Global.disable_button(Global.remove_layer_button, true)
 		Global.disable_button(Global.move_up_layer_button, true)

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -45,11 +45,13 @@ var file_format: int = Export.FileFormat.PNG
 var was_exported := false
 var export_overwrite := false
 
+# TODO: These should be able to be removed....
 var frame_button_node = preload("res://src/UI/Timeline/FrameButton.tscn")
 var pixel_layer_button_node = preload("res://src/UI/Timeline/PixelLayerButton.tscn")
 var group_layer_button_node = preload("res://src/UI/Timeline/GroupLayerButton.tscn")
 var pixel_cel_button_node = preload("res://src/UI/Timeline/PixelCelButton.tscn")
 var group_cel_button_node = preload("res://src/UI/Timeline/GroupCelButton.tscn")
+# ... up to this:
 var animation_tag_node = preload("res://src/UI/Timeline/AnimationTagUI.tscn")
 
 
@@ -140,63 +142,65 @@ func _selection_offset_changed(value: Vector2) -> void:
 
 func change_project() -> void:
 	# Remove old nodes
-	for container in Global.layers_container.get_children():
-		container.queue_free()
+#	for container in Global.layers_container.get_children():
+#		container.queue_free()
+#
+#	_remove_cel_buttons()
+#
+#	for frame_id in Global.frame_ids.get_children():
+#		Global.frame_ids.remove_child(frame_id)
+#		frame_id.queue_free()
+#
+#	# Create new ones
+#	for i in range(layers.size() - 1, -1, -1):
+#		# Create layer buttons
+#		var layer_container: LayerButton
+#		if layers[i] is PixelLayer:
+#			layer_container = pixel_layer_button_node.instance()
+#		elif layers[i] is GroupLayer:
+#			layer_container = group_layer_button_node.instance()
+#		layer_container.layer = i
+#		if layers[i].name == "":
+#			layers[i].name = layers[i].get_default_name(i)
+#
+#		Global.layers_container.add_child(layer_container)
+#		layer_container.label.text = layers[i].name
+#		layer_container.line_edit.text = layers[i].name
+#
+#		var layer_cel_container := HBoxContainer.new()
+#		Global.frames_container.add_child(layer_cel_container)
+#		for j in range(frames.size()):  # Create Cel buttons
+#			var cel_button = pixel_cel_button_node.instance()
+#			cel_button.frame = j
+#			cel_button.layer = i
+#			# TODO: Mak sure this works properly with groups
+#			cel_button.get_child(0).texture = frames[j].cels[i].image_texture
+#			if j == current_frame and i == current_layer:
+#				cel_button.pressed = true
+#
+#			layer_cel_container.add_child(cel_button)
+#
+#		if (is_instance_valid(layers[i].parent)
+#				and not layers[i].parent.is_expanded_in_hierarchy()):
+#			layer_cel_container.visible = false
+#
+#	for j in range(frames.size()):  # Create frame ID labels
+#		var button: Button = frame_button_node.instance()
+#		button.frame = j
+#		button.rect_min_size.x = Global.animation_timeline.cel_size
+#		button.text = str(j + 1)
+#		if j == current_frame:
+#			button.add_color_override(
+#				"font_color", Global.control.theme.get_color("Selected Color", "Label")
+#			)
+#		Global.frame_ids.add_child(button)
+#
+#	var layer_button = Global.layers_container.get_child(
+#		Global.layers_container.get_child_count() - 1 - current_layer
+#	)
+#	layer_button.pressed = true
 
-	_remove_cel_buttons()
-
-	for frame_id in Global.frame_ids.get_children():
-		Global.frame_ids.remove_child(frame_id)
-		frame_id.queue_free()
-
-	# Create new ones
-	for i in range(layers.size() - 1, -1, -1):
-		# Create layer buttons
-		var layer_container: LayerButton
-		if layers[i] is PixelLayer:
-			layer_container = pixel_layer_button_node.instance()
-		elif layers[i] is GroupLayer:
-			layer_container = group_layer_button_node.instance()
-		layer_container.layer = i
-		if layers[i].name == "":
-			layers[i].name = layers[i].get_default_name(i)
-
-		Global.layers_container.add_child(layer_container)
-		layer_container.label.text = layers[i].name
-		layer_container.line_edit.text = layers[i].name
-
-		var layer_cel_container := HBoxContainer.new()
-		Global.frames_container.add_child(layer_cel_container)
-		for j in range(frames.size()):  # Create Cel buttons
-			var cel_button = pixel_cel_button_node.instance()
-			cel_button.frame = j
-			cel_button.layer = i
-			# TODO: Mak sure this works properly with groups
-			cel_button.get_child(0).texture = frames[j].cels[i].image_texture
-			if j == current_frame and i == current_layer:
-				cel_button.pressed = true
-
-			layer_cel_container.add_child(cel_button)
-
-		if (is_instance_valid(layers[i].parent)
-				and not layers[i].parent.is_expanded_in_hierarchy()):
-			layer_cel_container.visible = false
-
-	for j in range(frames.size()):  # Create frame ID labels
-		var button: Button = frame_button_node.instance()
-		button.frame = j
-		button.rect_min_size.x = Global.animation_timeline.cel_size
-		button.text = str(j + 1)
-		if j == current_frame:
-			button.add_color_override(
-				"font_color", Global.control.theme.get_color("Selected Color", "Label")
-			)
-		Global.frame_ids.add_child(button)
-
-	var layer_button = Global.layers_container.get_child(
-		Global.layers_container.get_child_count() - 1 - current_layer
-	)
-	layer_button.pressed = true
+	Global.animation_timeline.project_changed()
 
 	Global.current_frame_mark_label.text = "%s/%s" % [str(current_frame + 1), frames.size()]
 
@@ -459,36 +463,36 @@ func _frames_changed(value: Array) -> void:
 	Global.canvas.selection.transform_content_confirm()
 	frames = value
 	selected_cels.clear()
-	_remove_cel_buttons()
-
-	for frame_id in Global.frame_ids.get_children():
-		Global.frame_ids.remove_child(frame_id)
-		frame_id.queue_free()
-
-	for i in range(layers.size() - 1, -1, -1):
-		var layer_cel_container := HBoxContainer.new()
-		layer_cel_container.name = "FRAMESS " + str(i)
-		Global.frames_container.add_child(layer_cel_container)
-		for j in range(frames.size()):
-			if layers[i] is PixelLayer:
-				var cel_button = pixel_cel_button_node.instance()
-				cel_button.frame = j
-				cel_button.layer = i
-				cel_button.get_child(0).texture = frames[j].cels[i].image_texture
-				layer_cel_container.add_child(cel_button)
-			elif layers[i] is GroupLayer:
-				# TODO: Make GroupLayers work here
-				pass
-		if (is_instance_valid(layers[i].parent)
-				and not layers[i].parent.is_expanded_in_hierarchy()):
-			layer_cel_container.visible = false
-
-	for j in range(frames.size()):
-		var button: Button = frame_button_node.instance()
-		button.frame = j
-		button.rect_min_size.x = Global.animation_timeline.cel_size
-		button.text = str(j + 1)
-		Global.frame_ids.add_child(button)
+#	_remove_cel_buttons()
+#
+#	for frame_id in Global.frame_ids.get_children():
+#		Global.frame_ids.remove_child(frame_id)
+#		frame_id.queue_free()
+#
+#	for i in range(layers.size() - 1, -1, -1):
+#		var layer_cel_container := HBoxContainer.new()
+#		layer_cel_container.name = "FRAMESS " + str(i)
+#		Global.frames_container.add_child(layer_cel_container)
+#		for j in range(frames.size()):
+#			if layers[i] is PixelLayer:
+#				var cel_button = pixel_cel_button_node.instance()
+#				cel_button.frame = j
+#				cel_button.layer = i
+#				cel_button.get_child(0).texture = frames[j].cels[i].image_texture
+#				layer_cel_container.add_child(cel_button)
+#			elif layers[i] is GroupLayer:
+#				# TODO: Make GroupLayers work here
+#				pass
+#		if (is_instance_valid(layers[i].parent)
+#				and not layers[i].parent.is_expanded_in_hierarchy()):
+#			layer_cel_container.visible = false
+#
+#	for j in range(frames.size()):
+#		var button: Button = frame_button_node.instance()
+#		button.frame = j
+#		button.rect_min_size.x = Global.animation_timeline.cel_size
+#		button.text = str(j + 1)
+#		Global.frame_ids.add_child(button)
 
 	_set_timeline_first_and_last_frames()
 
@@ -501,50 +505,50 @@ func _layers_changed(value: Array) -> void:
 
 	selected_cels.clear()
 
-	for container in Global.layers_container.get_children():
-		container.queue_free()
-
-	_remove_cel_buttons()
-
-	for i in range(layers.size() - 1, -1, -1):
-		var layer_button: LayerButton
-		if layers[i] is PixelLayer:
-			layer_button = pixel_layer_button_node.instance()
-		elif layers[i] is GroupLayer:
-			layer_button = group_layer_button_node.instance()
-		layer_button.layer = i
-		layers[i].index = i
-		layers[i].project = self
-		if layers[i].name == "":
-			layers[i].name = layers[i].get_default_name(i)
-
-		Global.layers_container.add_child(layer_button)
-		layer_button.label.text = layers[i].name
-		layer_button.line_edit.text = layers[i].name
-
-		var layer_cel_container := HBoxContainer.new()
-		layer_cel_container.name = "LAYERSSS " + str(i)
-		Global.frames_container.add_child(layer_cel_container)
-		# TODO: FIGURE OUT FRAMES WITH GROUP LAYERS!
-		for j in range(frames.size()):
-			var cel_button # TODO: Figure out static typing (will there be a BaseCelButton?)
-			if layers[i] is PixelLayer:
-				cel_button = pixel_cel_button_node.instance()
-				cel_button.get_child(0).texture = frames[j].cels[i].image_texture
-			elif layers[i] is GroupLayer:
-				cel_button = group_cel_button_node.instance()
-			cel_button.frame = j
-			cel_button.layer = i
-			layer_cel_container.add_child(cel_button)
-		if (is_instance_valid(layers[i].parent)
-				and not layers[i].parent.is_expanded_in_hierarchy()):
-			layer_cel_container.visible = false
-
-	var layer_button = Global.layers_container.get_child(
-		Global.layers_container.get_child_count() - 1 - current_layer
-	)
-	layer_button.pressed = true
-	self.current_frame = current_frame  # Call frame_changed to update UI
+#	for container in Global.layers_container.get_children():
+#		container.queue_free()
+#
+#	_remove_cel_buttons()
+#
+#	for i in range(layers.size() - 1, -1, -1):
+#		var layer_button: LayerButton
+#		if layers[i] is PixelLayer:
+#			layer_button = pixel_layer_button_node.instance()
+#		elif layers[i] is GroupLayer:
+#			layer_button = group_layer_button_node.instance()
+#		layer_button.layer = i
+#		layers[i].index = i
+#		layers[i].project = self
+#		if layers[i].name == "":
+#			layers[i].name = layers[i].get_default_name(i)
+#
+#		Global.layers_container.add_child(layer_button)
+#		layer_button.label.text = layers[i].name
+#		layer_button.line_edit.text = layers[i].name
+#
+#		var layer_cel_container := HBoxContainer.new()
+#		layer_cel_container.name = "LAYERSSS " + str(i)
+#		Global.frames_container.add_child(layer_cel_container)
+#		# TODO: FIGURE OUT FRAMES WITH GROUP LAYERS!
+#		for j in range(frames.size()):
+#			var cel_button # TODO: Figure out static typing (will there be a BaseCelButton?)
+#			if layers[i] is PixelLayer:
+#				cel_button = pixel_cel_button_node.instance()
+#				cel_button.get_child(0).texture = frames[j].cels[i].image_texture
+#			elif layers[i] is GroupLayer:
+#				cel_button = group_cel_button_node.instance()
+#			cel_button.frame = j
+#			cel_button.layer = i
+#			layer_cel_container.add_child(cel_button)
+#		if (is_instance_valid(layers[i].parent)
+#				and not layers[i].parent.is_expanded_in_hierarchy()):
+#			layer_cel_container.visible = false
+#
+#	var layer_button = Global.layers_container.get_child(
+#		Global.layers_container.get_child_count() - 1 - current_layer
+#	)
+#	layer_button.pressed = true
+#	self.current_frame = current_frame  # Call frame_changed to update UI
 	_toggle_layer_buttons_layers()
 
 
@@ -916,80 +920,127 @@ func resize_bitmap_values(bitmap: BitMap, new_size: Vector2, flip_x: bool, flip_
 func add_frame(frame: Frame, index: int) -> void:
 	# TODO: May need to call _frames_changed setter here (at least for some of it)
 	frames.insert(index, frame)
-	current_frame = index # TODO Probably need to call setter
-	# TODO: Test link/unlink cels and animation tag pushing thoroughly, I'm not sure if they're
+	# TODO: Test link/unlink cels thoroughly, I'm not sure if they're
 	# 	easily reversable (probably possible though, tags may need an "undo" bool, links
 	# 	may work with a passed array, or maybe its better if they're just not handled here
 
-	# Link cels:
-	for l_i in range(layers.size()):
-		if layers[l_i].new_cels_linked:  # If the link button is pressed
-			layers[l_i].linked_cels.append(frame)
-			frame.cels[l_i].image = layers[l_i].linked_cels[0].cels[l_i].image
-			frame.cels[l_i].image_texture = layers[l_i].linked_cels[0].cels[l_i].image_texture
-
-	# PUSH AHEAD animation tags starting after the frame
-	for tag in animation_tags:
-		if index >= tag.from && index <= tag.to:
-			tag.to += 1
-		elif (index) < tag.from:
-			tag.from += 1
-			tag.to += 1
+#	# Link cels:
+#	for l_i in range(layers.size()):
+#		if layers[l_i].new_cels_linked:  # If the link button is pressed
+#			layers[l_i].linked_cels.append(frame)
+#			frame.cels[l_i].image = layers[l_i].linked_cels[0].cels[l_i].image
+#			frame.cels[l_i].image_texture = layers[l_i].linked_cels[0].cels[l_i].image_texture
+#
 
 	# TODO: Check if these (especially remove/move) mess up selection?
-	_frames_changed(frames)# TODO: Add Frame and Cel Buttons
+	_frames_changed(frames)# TODO: Remove
+	# TODO: These may need an if self == Global.current_project depending on use
+	Global.animation_timeline.project_frame_added(index)
+	# Update the frames and frame buttons:
+	for f in range(frames.size()):
+		Global.frame_ids.get_child(f).frame = f
+		Global.frame_ids.get_child(f).text = str(f + 1)
+	# Update the cel buttons:
+	for l in range(layers.size()):
+		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
+		for f in range(frames.size()):
+			layer_cel_container.get_child(f).frame = f
+			layer_cel_container.get_child(f).button_setup()
 
 
 func remove_frame(index: int) -> void:
 	# TODO: If this messes up selection, would doing multiple here help?
 	frames.remove(index)
-	# TODO: Figure out what to set current_frame to
-	current_frame -= 1
 
-	# Unlink cels:
-	for layer in layers:
-		for linked in layer.linked_cels:
-			if linked == frames[index]:
-				layer.linked_cels.erase(linked)
+#	# Unlink cels:
+#	for layer in layers:
+#		for linked in layer.linked_cels:
+#			if linked == frames[index]:
+#				layer.linked_cels.erase(linked)
 
-	# PUSH BACK animation tags starting after the frame
-	for tag in animation_tags:
-		if index >= tag.from && index <= tag.to:
-			tag.to -= 1
-		elif (index) < tag.from:
-			tag.from -= 1
-			tag.to -= 1
-
-	_frames_changed(frames)# TODO: Remove Frame/CelButtons
+	_frames_changed(frames)# TODO: Remove
+	Global.animation_timeline.project_frame_removed(index)
+	# Update the frames and frame buttons:
+	for f in range(frames.size()):
+		Global.frame_ids.get_child(f).frame = f
+		Global.frame_ids.get_child(f).text = str(f + 1)
+	# Update the cel buttons:
+	for l in range(layers.size()):
+		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
+		for f in range(frames.size()):
+			layer_cel_container.get_child(f).frame = f
+			layer_cel_container.get_child(f).button_setup()
 
 
 func move_frame(from_index: int, to_index: int) -> void:
 	var frame = frames[from_index]
 	frames.remove(from_index)
+	Global.animation_timeline.project_frame_removed(from_index)
 	# TODO: Ensure the final position is always right
 	frames.insert(to_index, frame)
 	# TODO: Set current frame
-	_frames_changed(frames)# TODO: Remove and then add Frame/CelButtons
+	Global.animation_timeline.project_frame_added(to_index)
+	_frames_changed(frames)# TODO: Remove
+	# Update the frames and frame buttons:
+	for f in range(frames.size()):
+		Global.frame_ids.get_child(f).frame = f
+		Global.frame_ids.get_child(f).text = str(f + 1)
+	# Update the cel buttons:
+	for l in range(layers.size()):
+		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
+		for f in range(frames.size()):
+			layer_cel_container.get_child(f).frame = f
+			layer_cel_container.get_child(f).button_setup()
+
+
+func swap_frame(a_index: int, b_index: int) -> void:
+	# TODO: current frame
+	var temp: Frame = frames[a_index]
+	frames[a_index] = frames[b_index]
+	frames[b_index] = temp
+	Global.animation_timeline.project_frame_removed(a_index)
+	Global.animation_timeline.project_frame_added(a_index)
+	Global.animation_timeline.project_frame_removed(b_index)
+	Global.animation_timeline.project_frame_added(b_index)
 
 
 func add_layer(layer: BaseLayer, index: int, cels: Array) -> void:
 	# TODO: Global.canvas.selection.transform_content_confirm()
 	layers.insert(index, layer)
-	current_layer = index # TODO: Setter (which is the preferred way to call it?)
 	for f in range(frames.size()):
 		frames[f].cels.insert(index, cels[f])
-	# TODO: Update layer index
-	_layers_changed(layers)# TODO: Add layer and cel buttons
+	layer.project = self
+	# TODO: Update layer index (and others, more efficient if add layer supports multiple)
+	# TODO: Update layer button indices
+	_layers_changed(layers)# TODO: Remove
+	Global.animation_timeline.project_layer_added(index)
+	# Update the layer indices and layer/cel buttons:
+	for l in range(layers.size()):
+		layers[l].index = l
+		Global.layers_container.get_child(layers.size() - 1 - l).layer = l
+		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
+		for f in range(frames.size()):
+			layer_cel_container.get_child(f).layer = l
+			layer_cel_container.get_child(f).button_setup()
 
 
 func remove_layer(index: int) -> void:
 	# TODO: Global.canvas.selection.transform_content_confirm()
 	layers.remove(index)
-	current_layer = index - 1 # TODO: Setter
 	for frame in frames:
 		frame.cels.remove(index)
-	# TODO: Update layer index
-	_layers_changed(layers)# TODO: Remove layer and cel buttons
+	# TODO: Update layer index (and others, more efficient if remove layer supports multiple)
+	# TODO: Update layer button indices
+	_layers_changed(layers)# TODO: Remove
+	Global.animation_timeline.project_layer_removed(index)
+	# Update the layer indices and layer/cel buttons:
+	for l in range(layers.size()):
+		layers[l].index = l
+		Global.layers_container.get_child(layers.size() - 1 - l).layer = l
+		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
+		for f in range(frames.size()):
+			layer_cel_container.get_child(f).layer = l
+			layer_cel_container.get_child(f).button_setup()
 
 
 # from_indices and to_indicies should start from the lowest index, and go up
@@ -1007,6 +1058,7 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 		for frame in frames:
 			removed_cels[i].append(frame.cels[from_indices[i] - i])
 			frame.cels.remove(from_indices[i] - i)
+		Global.animation_timeline.project_layer_removed(from_indices[i] - i)
 		# TODO: remove layer and cel buttons
 	for i in range(to_indices.size()):
 		layers.insert(to_indices[i], old_layers[from_indices[i]])
@@ -1014,11 +1066,46 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 		# TODO: Frames...
 		for f in range(frames.size()):
 			frames[f].cels.insert(to_indices[i], removed_cels[i][f])
+		Global.animation_timeline.project_layer_added(to_indices[i])
 		# TODO: Add layer and cel buttons
-	# TODO: Update layer index
+	# Update the layer indices and layer/cel buttons:
+	for l in range(layers.size()):
+		layers[l].index = l
+		Global.layers_container.get_child(layers.size() - 1 - l).layer = l
+		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
+		for f in range(frames.size()):
+			layer_cel_container.get_child(f).layer = l
+			layer_cel_container.get_child(f).button_setup()
 	_layers_changed(layers) # TODO Remove (needs buttons and index update)
 
 
-func move_cel() -> void:
-	# not sure about this one
-	pass
+func move_cel(from_frame: int, to_frame: int, layer: int) -> void:
+	# TODO: Current frame
+	# TODO: Current layer
+	var cel: BaseCel = frames[from_frame].cels[layer]
+	if from_frame < to_frame:
+		for f in range(from_frame + 1, to_frame + 1):
+			frames[f - 1].cels[layer] = frames[f].cels[layer]
+	else:
+		for f in range(to_frame, from_frame):
+			frames[f + 1].cels[layer] = frames[f].cels[layer]
+	frames[to_frame].cels[layer] = cel
+	Global.animation_timeline.project_cel_removed(from_frame, layer)
+	Global.animation_timeline.project_cel_added(to_frame, layer)
+	# Update the cel buttons for this layer:
+	var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - layer)
+	for f in range(frames.size()):
+		layer_cel_container.get_child(f).frame = f
+		layer_cel_container.get_child(f).button_setup()
+
+
+func swap_cel(a_frame: int, a_layer: int, b_frame: int, b_layer: int) -> void:
+	# TODO: Current frame
+	# TODO: Current layer
+	var temp: BaseCel = frames[a_frame].cels[a_layer]
+	frames[a_frame].cels[a_layer] = frames[b_frame].cels[b_layer]
+	frames[b_frame].cels[b_layer] = temp
+	Global.animation_timeline.project_cel_removed(a_frame, a_layer)
+	Global.animation_timeline.project_cel_added(a_frame, a_layer)
+	Global.animation_timeline.project_cel_removed(b_frame, b_layer)
+	Global.animation_timeline.project_cel_added(b_frame, b_layer)

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -1082,32 +1082,16 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 func move_cel(from_frame: int, to_frame: int, layer: int) -> void:
 	# TODO: Current frame
 	# TODO: Current layer
-
-	# TODO: Remove this debugging chunk:
-	var OG_CELS = []
-	for F in frames:
-		OG_CELS.append(F.cels[layer])
-
 	var cel: BaseCel = frames[from_frame].cels[layer]
-	if to_frame < from_frame:
-		# TODO: These cels were not always correct... verify they are:
-		# TODO: After testing for correctness, can you reduce the amoutn of +/- 1s?
-		for f in range(from_frame - 1, to_frame - 1, -1): # Backward range
-			frames[f + 1].cels[layer] = frames[f].cels[layer] # Move right
+	if from_frame < to_frame:
+		for f in range(from_frame, to_frame): # Forward range
+			frames[f].cels[layer] = frames[f + 1].cels[layer] # Move left
 	else:
-		for f in range(from_frame + 1, to_frame + 1): # Forward range
-			frames[f - 1].cels[layer] = frames[f].cels[layer] # Move left
+		for f in range(from_frame, to_frame, -1): # Backward range
+			frames[f].cels[layer] = frames[f - 1].cels[layer] # Move right
 	frames[to_frame].cels[layer] = cel
 	Global.animation_timeline.project_cel_removed(from_frame, layer)
 	Global.animation_timeline.project_cel_added(to_frame, layer)
-
-	# TODO: Remove this debugging chunk:
-	var TEMP_CEL_INDICES = []
-	for F in frames:
-		TEMP_CEL_INDICES.append(OG_CELS.find(F.cels[layer]))
-		assert(TEMP_CEL_INDICES.count(TEMP_CEL_INDICES[-1]) == 1)
-	print("From: ", from_frame, " To: ", to_frame)
-	print("CELS: ", TEMP_CEL_INDICES)
 
 	# Update the cel buttons for this layer:
 	var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - layer)

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -574,20 +574,20 @@ func _frame_changed(value: int) -> void:
 		selected_cels.append([current_frame, current_layer])
 	# Select the new frame
 	for cel in selected_cels:
-		var current_frame_tmp: int = cel[0]
-		var current_layer_tmp: int = cel[1]
-		if current_frame_tmp < Global.frame_ids.get_child_count():
-			var frame_button: BaseButton = Global.frame_ids.get_child(current_frame_tmp)
+		var frame: int = cel[0]
+		var layer: int = cel[1]
+		if frame < Global.frame_ids.get_child_count():
+			var frame_button: BaseButton = Global.frame_ids.get_child(frame)
 			frame_button.pressed = true
 
 		var container_child_count: int = Global.frames_container.get_child_count()
-		if current_layer_tmp < container_child_count:
+		if layer < container_child_count:
 			var container = Global.frames_container.get_child(
-				container_child_count - 1 - current_layer_tmp
+				container_child_count - 1 - layer
 			)
-			if current_frame_tmp < container.get_child_count():
-				var fbutton = container.get_child(current_frame_tmp)
-				fbutton.pressed = true
+			if frame < container.get_child_count():
+				var cel_button = container.get_child(frame)
+				cel_button.pressed = true
 
 	Global.disable_button(Global.remove_frame_button, frames.size() == 1)
 	Global.disable_button(Global.move_left_frame_button, frames.size() == 1 or current_frame == 0)
@@ -619,10 +619,10 @@ func _layer_changed(value: int) -> void:
 		layer_button.pressed = false
 
 	for cel in selected_cels:
-		var current_layer_tmp: int = cel[1]
-		if current_layer_tmp < Global.layers_container.get_child_count():
+		var layer: int = cel[1]
+		if layer < Global.layers_container.get_child_count():
 			var layer_button = Global.layers_container.get_child(
-				Global.layers_container.get_child_count() - 1 - current_layer_tmp
+				Global.layers_container.get_child_count() - 1 - layer
 			)
 			layer_button.pressed = true
 
@@ -1121,22 +1121,22 @@ func swap_cel(a_frame: int, a_layer: int, b_frame: int, b_layer: int) -> void:
 
 func _update_animation_timeline_selection() -> void:
 	for cel in selected_cels:
-		var current_frame_tmp: int = cel[0]
-		var current_layer_tmp: int = cel[1]
-		if current_frame_tmp < Global.frame_ids.get_child_count():
-			var frame_button: BaseButton = Global.frame_ids.get_child(current_frame_tmp)
+		var frame: int = cel[0]
+		var layer: int = cel[1]
+		if frame < Global.frame_ids.get_child_count():
+			var frame_button: BaseButton = Global.frame_ids.get_child(frame)
 			frame_button.pressed = true
 
 		var container_child_count: int = Global.frames_container.get_child_count()
-		if current_layer_tmp < container_child_count:
+		if layer < container_child_count:
 			var container = Global.frames_container.get_child(
-				container_child_count - 1 - current_layer_tmp
+				container_child_count - 1 - layer
 			)
-			if current_frame_tmp < container.get_child_count():
-				var cel_button = container.get_child(current_frame_tmp)
+			if frame < container.get_child_count():
+				var cel_button = container.get_child(frame)
 				cel_button.pressed = true
 
 			var layer_button = Global.layers_container.get_child(
-				container_child_count - 1 - current_layer_tmp
+				container_child_count - 1 - layer
 			)
 			layer_button.pressed = true

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -558,14 +558,13 @@ func _animation_tags_changed(value: Array) -> void:
 
 	_set_timeline_first_and_last_frames()
 
-# TODO R1: Is this really required in _frames_changed (or the add/remove frame funcs, seems to work fine without when playing anim)
+
 func _set_timeline_first_and_last_frames() -> void:
 	# This is useful in case tags get modified DURING the animation is playing
 	# otherwise, this code is useless in this context, since these values are being set
 	# when the play buttons get pressed anyway
 	Global.animation_timeline.first_frame = 0
 	Global.animation_timeline.last_frame = frames.size() - 1
-	# TODO NOTE: Perhaps its needed fo the play_only_tags bit?
 	if Global.play_only_tags:
 		for tag in animation_tags:
 			if current_frame + 1 >= tag.from && current_frame + 1 <= tag.to:

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -736,17 +736,17 @@ func resize_bitmap_values(bitmap: BitMap, new_size: Vector2, flip_x: bool, flip_
 func add_frames(new_frames: Array, indices: Array) -> void:  # indices should be in ascending order
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
-	for i in range(new_frames.size()):
+	for i in new_frames.size():
 		frames.insert(indices[i], new_frames[i])
 		Global.animation_timeline.project_frame_added(indices[i])
 	# Update the frames and frame buttons:
-	for f in range(frames.size()):
+	for f in frames.size():
 		Global.frame_ids.get_child(f).frame = f
 		Global.frame_ids.get_child(f).text = str(f + 1)
 	# Update the cel buttons:
-	for l in range(layers.size()):
+	for l in layers.size():
 		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
-		for f in range(frames.size()):
+		for f in frames.size():
 			layer_cel_container.get_child(f).frame = f
 			layer_cel_container.get_child(f).button_setup()
 	_set_timeline_first_and_last_frames()
@@ -755,18 +755,18 @@ func add_frames(new_frames: Array, indices: Array) -> void:  # indices should be
 func remove_frames(indices: Array) -> void:  # indices should be in ascending order
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
-	for i in range(indices.size()):
+	for i in indices.size():
 		# With each removed index, future indices need to be lowered, so subtract by i
 		frames.remove(indices[i] - i)
 		Global.animation_timeline.project_frame_removed(indices[i] - i)
 	# Update the frames and frame buttons:
-	for f in range(frames.size()):
+	for f in frames.size():
 		Global.frame_ids.get_child(f).frame = f
 		Global.frame_ids.get_child(f).text = str(f + 1)
 	# Update the cel buttons:
-	for l in range(layers.size()):
+	for l in layers.size():
 		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
-		for f in range(frames.size()):
+		for f in frames.size():
 			layer_cel_container.get_child(f).frame = f
 			layer_cel_container.get_child(f).button_setup()
 	_set_timeline_first_and_last_frames()
@@ -781,13 +781,13 @@ func move_frame(from_index: int, to_index: int) -> void:
 	frames.insert(to_index, frame)
 	Global.animation_timeline.project_frame_added(to_index)
 	# Update the frames and frame buttons:
-	for f in range(frames.size()):
+	for f in frames.size():
 		Global.frame_ids.get_child(f).frame = f
 		Global.frame_ids.get_child(f).text = str(f + 1)
 	# Update the cel buttons:
-	for l in range(layers.size()):
+	for l in layers.size():
 		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
-		for f in range(frames.size()):
+		for f in frames.size():
 			layer_cel_container.get_child(f).frame = f
 			layer_cel_container.get_child(f).button_setup()
 	_set_timeline_first_and_last_frames()
@@ -809,18 +809,18 @@ func swap_frame(a_index: int, b_index: int) -> void:
 func add_layers(new_layers: Array, indices: Array, cels: Array) -> void:  # cels is 2d Array of cels
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
-	for i in range(indices.size()):
+	for i in indices.size():
 		layers.insert(indices[i], new_layers[i])
-		for f in range(frames.size()):
+		for f in frames.size():
 			frames[f].cels.insert(indices[i], cels[i][f])
 		new_layers[i].project = self
 		Global.animation_timeline.project_layer_added(indices[i])
 	# Update the layer indices and layer/cel buttons:
-	for l in range(layers.size()):
+	for l in layers.size():
 		layers[l].index = l
 		Global.layers_container.get_child(layers.size() - 1 - l).layer = l
 		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
-		for f in range(frames.size()):
+		for f in frames.size():
 			layer_cel_container.get_child(f).layer = l
 			layer_cel_container.get_child(f).button_setup()
 	toggle_layer_buttons()
@@ -829,18 +829,18 @@ func add_layers(new_layers: Array, indices: Array, cels: Array) -> void:  # cels
 func remove_layers(indices: Array) -> void:
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
-	for i in range(indices.size()):
+	for i in indices.size():
 		# With each removed index, future indices need to be lowered, so subtract by i
 		layers.remove(indices[i] - i)
 		for frame in frames:
 			frame.cels.remove(indices[i] - i)
 		Global.animation_timeline.project_layer_removed(indices[i] - i)
 	# Update the layer indices and layer/cel buttons:
-	for l in range(layers.size()):
+	for l in layers.size():
 		layers[l].index = l
 		Global.layers_container.get_child(layers.size() - 1 - l).layer = l
 		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
-		for f in range(frames.size()):
+		for f in frames.size():
 			layer_cel_container.get_child(f).layer = l
 			layer_cel_container.get_child(f).button_setup()
 	toggle_layer_buttons()
@@ -863,15 +863,15 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 		Global.animation_timeline.project_layer_removed(from_indices[i] - i)
 	for i in to_indices.size():
 		layers.insert(to_indices[i], removed_layers[i])
-		for f in range(frames.size()):
+		for f in frames.size():
 			frames[f].cels.insert(to_indices[i], removed_cels[i][f])
 		Global.animation_timeline.project_layer_added(to_indices[i])
 	# Update the layer indices and layer/cel buttons:
-	for l in range(layers.size()):
+	for l in layers.size():
 		layers[l].index = l
 		Global.layers_container.get_child(layers.size() - 1 - l).layer = l
 		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
-		for f in range(frames.size()):
+		for f in frames.size():
 			layer_cel_container.get_child(f).layer = l
 			layer_cel_container.get_child(f).button_setup()
 	toggle_layer_buttons()
@@ -905,21 +905,21 @@ func swap_layers(a: Dictionary, b: Dictionary) -> void:
 	for i in a_layers.size():
 		var index = a.to[i] if a.to[0] < b.to[0] else (a.to[i] - b.to.size())
 		layers.insert(index, a_layers[i])
-		for f in range(frames.size()):
+		for f in frames.size():
 			frames[f].cels.insert(index, a_cels[i][f])
 		Global.animation_timeline.project_layer_added(index)
 	for i in b_layers.size():
 		layers.insert(b.to[i], b_layers[i])
-		for f in range(frames.size()):
+		for f in frames.size():
 			frames[f].cels.insert(b.to[i], b_cels[i][f])
 		Global.animation_timeline.project_layer_added(b.to[i])
 
 	# Update the layer indices and layer/cel buttons:
-	for l in range(layers.size()):
+	for l in layers.size():
 		layers[l].index = l
 		Global.layers_container.get_child(layers.size() - 1 - l).layer = l
 		var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - l)
-		for f in range(frames.size()):
+		for f in frames.size():
 			layer_cel_container.get_child(f).layer = l
 			layer_cel_container.get_child(f).button_setup()
 	toggle_layer_buttons()
@@ -941,7 +941,7 @@ func move_cel(from_frame: int, to_frame: int, layer: int) -> void:
 
 	# Update the cel buttons for this layer:
 	var layer_cel_container = Global.frames_container.get_child(layers.size() - 1 - layer)
-	for f in range(frames.size()):
+	for f in frames.size():
 		layer_cel_container.get_child(f).frame = f
 		layer_cel_container.get_child(f).button_setup()
 

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -849,15 +849,15 @@ func swap_frame(a_index: int, b_index: int) -> void:
 	Global.animation_timeline.project_frame_added(b_index)
 
 
-func add_layer(layer: BaseLayer, index: int, cels: Array) -> void:
+func add_layers(new_layers: Array, indices: Array, cels: Array) -> void:  # cels is 2d Array of cels
 	assert(self == Global.current_project) # TODO R: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
 	selected_cels.clear()
-	layers.insert(index, layer)
-	for f in range(frames.size()):
-		frames[f].cels.insert(index, cels[f])
-	layer.project = self
-	# TODO R: Update layer index (and others, more efficient if add layer supports multiple)
-	Global.animation_timeline.project_layer_added(index)
+	for i in range(indices.size()):
+		layers.insert(indices[i], new_layers[i])
+		for f in range(frames.size()):
+			frames[f].cels.insert(indices[i], cels[i][f])
+		new_layers[i].project = self
+		Global.animation_timeline.project_layer_added(indices[i])
 	# Update the layer indices and layer/cel buttons:
 	for l in range(layers.size()):
 		layers[l].index = l
@@ -869,13 +869,14 @@ func add_layer(layer: BaseLayer, index: int, cels: Array) -> void:
 	_toggle_layer_buttons_layers()
 
 
-func remove_layer(index: int) -> void:
+func remove_layers(indices: Array) -> void:
 	selected_cels.clear()
-	layers.remove(index)
-	for frame in frames:
-		frame.cels.remove(index)
-	# TODO R: Update layer index (and others, more efficient if remove layer supports multiple)
-	Global.animation_timeline.project_layer_removed(index)
+	for i in range(indices.size()):
+		# With each removed index, future indices need to be lowered, so subtract by i
+		layers.remove(indices[i] - i)
+		for frame in frames:
+			frame.cels.remove(indices[i] - i)
+		Global.animation_timeline.project_layer_removed(indices[i] - i)
 	# Update the layer indices and layer/cel buttons:
 	for l in range(layers.size()):
 		layers[l].index = l

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -45,7 +45,7 @@ var file_format: int = Export.FileFormat.PNG
 var was_exported := false
 var export_overwrite := false
 
-# TODO: These should be able to be removed....
+# TODO R: These should be able to be removed....
 var frame_button_node = preload("res://src/UI/Timeline/FrameButton.tscn")
 var pixel_layer_button_node = preload("res://src/UI/Timeline/PixelLayerButton.tscn")
 var group_layer_button_node = preload("res://src/UI/Timeline/GroupLayerButton.tscn")
@@ -403,7 +403,7 @@ func _size_changed(value: Vector2) -> void:
 func _frames_changed(value: Array) -> void:
 	Global.canvas.selection.transform_content_confirm()
 	frames = value
-#	selected_cels.clear() # TODO: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
+#	selected_cels.clear() # TODO R: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
 	_set_timeline_first_and_last_frames()
 
 
@@ -413,8 +413,8 @@ func _layers_changed(value: Array) -> void:
 		Global.layers_changed_skip = false
 		return
 
-#	selected_cels.clear() # TODO: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
-	# TODO: investigate wether these are still required:
+#	selected_cels.clear() # TODO R: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
+	# TODO R: investigate wether these are still required:
 #	var layer_button = Global.layers_container.get_child(
 #		Global.layers_container.get_child_count() - 1 - current_layer
 #	)
@@ -467,7 +467,7 @@ func _frame_changed(value: int) -> void:
 	)
 
 	if current_frame < frames.size():
-		# TODO: Make this work with groups:
+		# TODO H: Make this work with groups:
 		if not layers[current_layer] is GroupLayer:
 			var cel_opacity: float = frames[current_frame].cels[current_layer].opacity
 			Global.layer_opacity_slider.value = cel_opacity * 100
@@ -560,7 +560,7 @@ func _animation_tags_changed(value: Array) -> void:
 
 	_set_timeline_first_and_last_frames()
 
-# TODO: Is this really required in _frames_changed (or the add/remove frame funcs, seems to work fine without when playing anim)
+# TODO R: Is this really required in _frames_changed (or the add/remove frame funcs, seems to work fine without when playing anim)
 func _set_timeline_first_and_last_frames() -> void:
 	# This is useful in case tags get modified DURING the animation is playing
 	# otherwise, this code is useless in this context, since these values are being set
@@ -605,13 +605,12 @@ func is_empty() -> bool:
 
 
 func duplicate_layers() -> Array:
-	# TODO: May want to test this a bit after refactor
+	# TODO R: May want to test this a bit after refactor
 	var new_layers: Array = layers.duplicate()
 	# Loop through the array to create new classes for each element, so that they
 	# won't be the same as the original array's classes. Needed for undo/redo to work properly.
 	for i in new_layers.size():
 		new_layers[i] = new_layers[i].copy()
-
 	return new_layers
 
 
@@ -780,7 +779,7 @@ func resize_bitmap_values(bitmap: BitMap, new_size: Vector2, flip_x: bool, flip_
 
 
 func add_frames(new_frames: Array, indices: Array) -> void:  # indices should be in ascending order
-	assert(self == Global.current_project) # TODO: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
+	assert(self == Global.current_project) # TODO R: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
 	for i in range(new_frames.size()):
@@ -801,8 +800,7 @@ func add_frames(new_frames: Array, indices: Array) -> void:  # indices should be
 func remove_frames(indices: Array) -> void:  # indices should be in ascending order
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
-	# TODO: If this messes up selection, would doing multiple here help?
-	# TODO: Could one half of cel linking and animation tags be included in the add or remove_frame functions? (ie: removing works, but adding doesn't?)
+	# TODO R: Could one half of cel linking and animation tags be included in the add or remove_frame functions? (ie: removing works, but adding doesn't?)
 	for i in range(indices.size()):
 		# With each removed index, future indices need to be lowered, so subtract by i
 		frames.remove(indices[i] - i)
@@ -852,14 +850,13 @@ func swap_frame(a_index: int, b_index: int) -> void:
 
 
 func add_layer(layer: BaseLayer, index: int, cels: Array) -> void:
-	assert(self == Global.current_project) # TODO: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
-	# TODO: is Global.canvas.selection.transform_content_confirm() needed for layer changes (it wasn't used before I think)
+	assert(self == Global.current_project) # TODO R: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
 	selected_cels.clear()
 	layers.insert(index, layer)
 	for f in range(frames.size()):
 		frames[f].cels.insert(index, cels[f])
 	layer.project = self
-	# TODO: Update layer index (and others, more efficient if add layer supports multiple)
+	# TODO R: Update layer index (and others, more efficient if add layer supports multiple)
 	Global.animation_timeline.project_layer_added(index)
 	# Update the layer indices and layer/cel buttons:
 	for l in range(layers.size()):
@@ -877,7 +874,7 @@ func remove_layer(index: int) -> void:
 	layers.remove(index)
 	for frame in frames:
 		frame.cels.remove(index)
-	# TODO: Update layer index (and others, more efficient if remove layer supports multiple)
+	# TODO R: Update layer index (and others, more efficient if remove layer supports multiple)
 	Global.animation_timeline.project_layer_removed(index)
 	# Update the layer indices and layer/cel buttons:
 	for l in range(layers.size()):
@@ -892,8 +889,7 @@ func remove_layer(index: int) -> void:
 
 # from_indices and to_indicies should be in ascending order
 func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> void:
-	# TODO: it may be good to do a test run with using loops of add/remove_layer instead of using move_layers
-	# TODO: to_parents could just be a single for now, but then how should move_layers be named?
+	# TODO R: it may be good to do a test run with using add/remove_layers instead of using move_layers
 	selected_cels.clear()
 	var old_layers := layers.duplicate()
 	var removed_cels := [] # Array of array of cels (an array for each layer removed)
@@ -908,7 +904,7 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 		Global.animation_timeline.project_layer_removed(from_indices[i] - i)
 	for i in range(to_indices.size()):
 		layers.insert(to_indices[i], old_layers[from_indices[i]])
-		layers[to_indices[i]].parent = to_parents[i] # TODO: it could be possible to do the to_parents when removing (previous loop), allowing this loop to be recombined with the next
+		layers[to_indices[i]].parent = to_parents[i] # TODO R: it could be possible to do the to_parents when removing (previous loop), allowing this loop to be recombined with the next
 		for f in range(frames.size()):
 			frames[f].cels.insert(to_indices[i], removed_cels[i][f])
 	for i in range(to_indices.size()): # Loop again (All parents must be set before adding the UI)
@@ -926,7 +922,7 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 
 func swap_layers() -> void:
 	selected_cels.clear()
-	# TODO: Implement swap_layers
+	# TODO R: Implement swap_layers
 	pass
 	_toggle_layer_buttons_layers()
 

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -141,65 +141,6 @@ func _selection_offset_changed(value: Vector2) -> void:
 
 
 func change_project() -> void:
-	# Remove old nodes
-#	for container in Global.layers_container.get_children():
-#		container.queue_free()
-#
-#	_remove_cel_buttons()
-#
-#	for frame_id in Global.frame_ids.get_children():
-#		Global.frame_ids.remove_child(frame_id)
-#		frame_id.queue_free()
-#
-#	# Create new ones
-#	for i in range(layers.size() - 1, -1, -1):
-#		# Create layer buttons
-#		var layer_container: LayerButton
-#		if layers[i] is PixelLayer:
-#			layer_container = pixel_layer_button_node.instance()
-#		elif layers[i] is GroupLayer:
-#			layer_container = group_layer_button_node.instance()
-#		layer_container.layer = i
-#		if layers[i].name == "":
-#			layers[i].name = layers[i].get_default_name(i)
-#
-#		Global.layers_container.add_child(layer_container)
-#		layer_container.label.text = layers[i].name
-#		layer_container.line_edit.text = layers[i].name
-#
-#		var layer_cel_container := HBoxContainer.new()
-#		Global.frames_container.add_child(layer_cel_container)
-#		for j in range(frames.size()):  # Create Cel buttons
-#			var cel_button = pixel_cel_button_node.instance()
-#			cel_button.frame = j
-#			cel_button.layer = i
-#			# TODO: Mak sure this works properly with groups
-#			cel_button.get_child(0).texture = frames[j].cels[i].image_texture
-#			if j == current_frame and i == current_layer:
-#				cel_button.pressed = true
-#
-#			layer_cel_container.add_child(cel_button)
-#
-#		if (is_instance_valid(layers[i].parent)
-#				and not layers[i].parent.is_expanded_in_hierarchy()):
-#			layer_cel_container.visible = false
-#
-#	for j in range(frames.size()):  # Create frame ID labels
-#		var button: Button = frame_button_node.instance()
-#		button.frame = j
-#		button.rect_min_size.x = Global.animation_timeline.cel_size
-#		button.text = str(j + 1)
-#		if j == current_frame:
-#			button.add_color_override(
-#				"font_color", Global.control.theme.get_color("Selected Color", "Label")
-#			)
-#		Global.frame_ids.add_child(button)
-#
-#	var layer_button = Global.layers_container.get_child(
-#		Global.layers_container.get_child_count() - 1 - current_layer
-#	)
-#	layer_button.pressed = true
-
 	Global.animation_timeline.project_changed()
 
 	Global.current_frame_mark_label.text = "%s/%s" % [str(current_frame + 1), frames.size()]
@@ -463,36 +404,6 @@ func _frames_changed(value: Array) -> void:
 	Global.canvas.selection.transform_content_confirm()
 	frames = value
 #	selected_cels.clear() # TODO: This is commented out to prevent selected_cels being blank at begginning (Will it still be needed? Will removing the setter calls in the new functions fix it?)
-#	_remove_cel_buttons()
-#
-#	for frame_id in Global.frame_ids.get_children():
-#		Global.frame_ids.remove_child(frame_id)
-#		frame_id.queue_free()
-#
-#	for i in range(layers.size() - 1, -1, -1):
-#		var layer_cel_container := HBoxContainer.new()
-#		layer_cel_container.name = "FRAMESS " + str(i)
-#		Global.frames_container.add_child(layer_cel_container)
-#		for j in range(frames.size()):
-#			if layers[i] is PixelLayer:
-#				var cel_button = pixel_cel_button_node.instance()
-#				cel_button.frame = j
-#				cel_button.layer = i
-#				cel_button.get_child(0).texture = frames[j].cels[i].image_texture
-#				layer_cel_container.add_child(cel_button)
-#			elif layers[i] is GroupLayer:
-#				# TODO: Make GroupLayers work here
-#				pass
-#		if (is_instance_valid(layers[i].parent)
-#				and not layers[i].parent.is_expanded_in_hierarchy()):
-#			layer_cel_container.visible = false
-#
-#	for j in range(frames.size()):
-#		var button: Button = frame_button_node.instance()
-#		button.frame = j
-#		button.rect_min_size.x = Global.animation_timeline.cel_size
-#		button.text = str(j + 1)
-#		Global.frame_ids.add_child(button)
 
 	_set_timeline_first_and_last_frames()
 
@@ -505,45 +416,6 @@ func _layers_changed(value: Array) -> void:
 
 #	selected_cels.clear() # TODO: This is commented out to prevent selected_cels being blank at begginning (Will it still be needed? Will removing the setter calls in the new functions fix it?)
 
-#	for container in Global.layers_container.get_children():
-#		container.queue_free()
-#
-#	_remove_cel_buttons()
-#
-#	for i in range(layers.size() - 1, -1, -1):
-#		var layer_button: LayerButton
-#		if layers[i] is PixelLayer:
-#			layer_button = pixel_layer_button_node.instance()
-#		elif layers[i] is GroupLayer:
-#			layer_button = group_layer_button_node.instance()
-#		layer_button.layer = i
-#		layers[i].index = i
-#		layers[i].project = self
-#		if layers[i].name == "":
-#			layers[i].name = layers[i].get_default_name(i)
-#
-#		Global.layers_container.add_child(layer_button)
-#		layer_button.label.text = layers[i].name
-#		layer_button.line_edit.text = layers[i].name
-#
-#		var layer_cel_container := HBoxContainer.new()
-#		layer_cel_container.name = "LAYERSSS " + str(i)
-#		Global.frames_container.add_child(layer_cel_container)
-#		# TODO: FIGURE OUT FRAMES WITH GROUP LAYERS!
-#		for j in range(frames.size()):
-#			var cel_button # TODO: Figure out static typing (will there be a BaseCelButton?)
-#			if layers[i] is PixelLayer:
-#				cel_button = pixel_cel_button_node.instance()
-#				cel_button.get_child(0).texture = frames[j].cels[i].image_texture
-#			elif layers[i] is GroupLayer:
-#				cel_button = group_cel_button_node.instance()
-#			cel_button.frame = j
-#			cel_button.layer = i
-#			layer_cel_container.add_child(cel_button)
-#		if (is_instance_valid(layers[i].parent)
-#				and not layers[i].parent.is_expanded_in_hierarchy()):
-#			layer_cel_container.visible = false
-#
 #	var layer_button = Global.layers_container.get_child(
 #		Global.layers_container.get_child_count() - 1 - current_layer
 #	)

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -397,7 +397,7 @@ func _size_changed(value: Vector2) -> void:
 func _frames_changed(value: Array) -> void:
 	Global.canvas.selection.transform_content_confirm()
 	frames = value
-#	selected_cels.clear() # TODO R: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
+#	selected_cels.clear() # TODO R2: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
 	_set_timeline_first_and_last_frames()
 
 
@@ -407,8 +407,8 @@ func _layers_changed(value: Array) -> void:
 		Global.layers_changed_skip = false
 		return
 
-#	selected_cels.clear() # TODO R: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
-	# TODO R: investigate wether these are still required:
+#	selected_cels.clear() # TODO R2: Determine if this needs to be kept (If it is, selected cels needs to be intialized after creating project (ie: in Main), rather than here
+	# TODO R2: investigate wether these are still required:
 #	var layer_button = Global.layers_container.get_child(
 #		Global.layers_container.get_child_count() - 1 - current_layer
 #	)
@@ -454,7 +454,7 @@ func _frame_changed(value: int) -> void:
 				var cel_button = container.get_child(frame)
 				cel_button.pressed = true
 
-	# TODO R: When starting up, with only one frame, these aren't getting called:
+	# TODO R0: When starting up, with only one frame, these aren't getting called:
 	Global.disable_button(Global.remove_frame_button, frames.size() == 1)
 	Global.disable_button(Global.move_left_frame_button, frames.size() == 1 or current_frame == 0)
 	Global.disable_button(
@@ -555,7 +555,7 @@ func _animation_tags_changed(value: Array) -> void:
 
 	_set_timeline_first_and_last_frames()
 
-# TODO R: Is this really required in _frames_changed (or the add/remove frame funcs, seems to work fine without when playing anim)
+# TODO R1: Is this really required in _frames_changed (or the add/remove frame funcs, seems to work fine without when playing anim)
 func _set_timeline_first_and_last_frames() -> void:
 	# This is useful in case tags get modified DURING the animation is playing
 	# otherwise, this code is useless in this context, since these values are being set
@@ -600,7 +600,7 @@ func is_empty() -> bool:
 
 
 func duplicate_layers() -> Array:
-	# TODO R: May want to test this a bit after refactor
+	# TODO R1: May want to test this a bit after refactor
 	# TODO H: When duplicating the layers, parent references would be using the old layers now, this will probably cause bugs
 	var new_layers: Array = layers.duplicate()
 	# Loop through the array to create new classes for each element, so that they
@@ -775,7 +775,7 @@ func resize_bitmap_values(bitmap: BitMap, new_size: Vector2, flip_x: bool, flip_
 
 
 func add_frames(new_frames: Array, indices: Array) -> void:  # indices should be in ascending order
-	assert(self == Global.current_project) # TODO R: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
+	assert(self == Global.current_project) # TODO R3: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
 	for i in range(new_frames.size()):
@@ -796,7 +796,7 @@ func add_frames(new_frames: Array, indices: Array) -> void:  # indices should be
 func remove_frames(indices: Array) -> void:  # indices should be in ascending order
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
-	# TODO R: Could one half of cel linking and animation tags be included in the add or remove_frame functions? (ie: removing works, but adding doesn't?)
+	# TODO R1: Could one half of cel linking and animation tags be included in the add or remove_frame functions? (ie: removing works, but adding doesn't?)
 	for i in range(indices.size()):
 		# With each removed index, future indices need to be lowered, so subtract by i
 		frames.remove(indices[i] - i)
@@ -846,7 +846,7 @@ func swap_frame(a_index: int, b_index: int) -> void:
 
 
 func add_layers(new_layers: Array, indices: Array, cels: Array) -> void:  # cels is 2d Array of cels
-	assert(self == Global.current_project) # TODO R: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
+	assert(self == Global.current_project) # TODO R3: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
 	selected_cels.clear()
 	for i in range(indices.size()):
 		layers.insert(indices[i], new_layers[i])
@@ -886,9 +886,8 @@ func remove_layers(indices: Array) -> void:
 
 # from_indices and to_indicies should be in ascending order
 func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> void:
-	# TODO R: it may be good to do a test run with using add/remove_layers instead of using move_layers
 	selected_cels.clear()
-	var old_layers := layers.duplicate() # TODO R: Could maybe change to just empty layers array, using append(pop_at) trick like in swap_layers
+	var old_layers := layers.duplicate() # TODO R1: Could maybe change to just empty layers array, using append(pop_at) trick like in swap_layers
 	var removed_cels := [] # 2D array of cels (an array for each layer removed)
 
 	for i in range(from_indices.size()):
@@ -900,7 +899,7 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 		Global.animation_timeline.project_layer_removed(from_indices[i] - i)
 	for i in range(to_indices.size()):
 		layers.insert(to_indices[i], old_layers[from_indices[i]])
-		layers[to_indices[i]].parent = to_parents[i] # TODO R: it could be possible to do the to_parents when removing (previous loop), allowing this loop to be recombined with the next
+		layers[to_indices[i]].parent = to_parents[i] # TODO R1: it could be possible to do the to_parents when removing (previous loop), allowing this loop to be recombined with the next
 		for f in range(frames.size()):
 			frames[f].cels.insert(to_indices[i], removed_cels[i][f])
 	for i in range(to_indices.size()): # Loop again (All parents must be set before adding the UI)
@@ -920,7 +919,7 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 # (Using dictionaries because there seems to be a limit of 5 arguments for do/undo method calls)
 func swap_layers(a: Dictionary, b: Dictionary) -> void:
 	selected_cels.clear()
-	print("a: ", a, "  b: ", b) # TODO R: Remove
+	print("a: ", a, "  b: ", b) # TODO R3: Remove
 	var a_layers := []
 	var b_layers := []
 	var a_cels := [] # 2D array of cels (an array for each layer removed)

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -800,7 +800,6 @@ func add_frames(new_frames: Array, indices: Array) -> void:  # indices should be
 func remove_frames(indices: Array) -> void:  # indices should be in ascending order
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
-	# TODO R1: Could one half of cel linking and animation tags be included in the add or remove_frame functions? (ie: removing works, but adding doesn't?)
 	for i in range(indices.size()):
 		# With each removed index, future indices need to be lowered, so subtract by i
 		frames.remove(indices[i] - i)

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -144,7 +144,7 @@ func change_project() -> void:
 	Global.disable_button(
 		Global.move_right_frame_button, frames.size() == 1 or current_frame == frames.size() - 1
 	)
-	_toggle_layer_buttons()
+	toggle_layer_buttons()
 
 	self.animation_tags = animation_tags
 
@@ -413,7 +413,7 @@ func _layers_changed(value: Array) -> void:
 #	)
 #	layer_button.pressed = true
 #	self.current_frame = current_frame  # Call frame_changed to update UI
-	_toggle_layer_buttons()
+	toggle_layer_buttons()
 
 
 func _remove_cel_buttons() -> void:
@@ -453,18 +453,12 @@ func _frame_changed(value: int) -> void:
 				var cel_button = container.get_child(frame)
 				cel_button.pressed = true
 
-	# TODO R0: When starting up, with only one frame, these aren't getting called:
-	Global.disable_button(Global.remove_frame_button, frames.size() == 1)
-	Global.disable_button(Global.move_left_frame_button, frames.size() == 1 or current_frame == 0)
-	Global.disable_button(
-		Global.move_right_frame_button, frames.size() == 1 or current_frame == frames.size() - 1
-	)
-
 	if current_frame < frames.size():
 		var cel_opacity: float = frames[current_frame].cels[current_layer].opacity
 		Global.layer_opacity_slider.value = cel_opacity * 100
 		Global.layer_opacity_spinbox.value = cel_opacity * 100
 
+	toggle_frame_buttons()
 	Global.canvas.update()
 	Global.transparent_checker.update_rect()
 
@@ -473,7 +467,7 @@ func _layer_changed(value: int) -> void:
 	Global.canvas.selection.transform_content_confirm()
 	current_layer = value
 
-	_toggle_layer_buttons()
+	toggle_layer_buttons()
 
 	yield(Global.get_tree().create_timer(0.01), "timeout")
 	self.current_frame = current_frame  # Call frame_changed to update UI
@@ -489,7 +483,15 @@ func _layer_changed(value: int) -> void:
 			layer_button.pressed = true
 
 
-func _toggle_layer_buttons() -> void:
+func toggle_frame_buttons() -> void:
+	Global.disable_button(Global.remove_frame_button, frames.size() == 1)
+	Global.disable_button(Global.move_left_frame_button, frames.size() == 1 or current_frame == 0)
+	Global.disable_button(
+		Global.move_right_frame_button, frames.size() == 1 or current_frame == frames.size() - 1
+	)
+
+
+func toggle_layer_buttons() -> void:
 	if layers.empty() or current_layer >= layers.size():
 		return
 	var child_count: int = layers[current_layer].get_children_recursive().size()
@@ -844,7 +846,7 @@ func add_layers(new_layers: Array, indices: Array, cels: Array) -> void:  # cels
 		for f in range(frames.size()):
 			layer_cel_container.get_child(f).layer = l
 			layer_cel_container.get_child(f).button_setup()
-	_toggle_layer_buttons()
+	toggle_layer_buttons()
 
 
 func remove_layers(indices: Array) -> void:
@@ -863,7 +865,7 @@ func remove_layers(indices: Array) -> void:
 		for f in range(frames.size()):
 			layer_cel_container.get_child(f).layer = l
 			layer_cel_container.get_child(f).button_setup()
-	_toggle_layer_buttons()
+	toggle_layer_buttons()
 
 
 # from_indices and to_indicies should be in ascending order
@@ -894,7 +896,7 @@ func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> v
 		for f in range(frames.size()):
 			layer_cel_container.get_child(f).layer = l
 			layer_cel_container.get_child(f).button_setup()
-	_toggle_layer_buttons()
+	toggle_layer_buttons()
 
 
 # "a" and "b" should both contain "from", "to", and "to_parents" arrays.
@@ -942,7 +944,7 @@ func swap_layers(a: Dictionary, b: Dictionary) -> void:
 		for f in range(frames.size()):
 			layer_cel_container.get_child(f).layer = l
 			layer_cel_container.get_child(f).button_setup()
-	_toggle_layer_buttons()
+	toggle_layer_buttons()
 
 
 func move_cel(from_frame: int, to_frame: int, layer: int) -> void:

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -606,6 +606,7 @@ func is_empty() -> bool:
 
 func duplicate_layers() -> Array:
 	# TODO R: May want to test this a bit after refactor
+	# TODO H: When duplicating the layers, parent references would be using the old layers now, this will probably cause bugs
 	var new_layers: Array = layers.duplicate()
 	# Loop through the array to create new classes for each element, so that they
 	# won't be the same as the original array's classes. Needed for undo/redo to work properly.

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -605,20 +605,12 @@ func is_empty() -> bool:
 
 
 func duplicate_layers() -> Array:
+	# TODO: May want to test this a bit after refactor
 	var new_layers: Array = layers.duplicate()
 	# Loop through the array to create new classes for each element, so that they
 	# won't be the same as the original array's classes. Needed for undo/redo to work properly.
 	for i in new_layers.size():
-		var layer_dict: Dictionary = new_layers[i].serialize()
-		#layer_dict.linked_cels = new_layers[i].linked_cels.duplicate()
-		match layer_dict.type:
-			Global.LayerTypes.PIXEL:
-				new_layers[i] = PixelLayer.new()
-			Global.LayerTypes.GROUP:
-				new_layers[i] = GroupLayer.new()
-		new_layers[i].index = i
-		new_layers[i].project = self
-		new_layers[i].deserialize(layer_dict)
+		new_layers[i] = new_layers[i].copy()
 
 	return new_layers
 

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -787,13 +787,13 @@ func resize_bitmap_values(bitmap: BitMap, new_size: Vector2, flip_x: bool, flip_
 	return new_bitmap
 
 
-func add_frame(frame: Frame, index: int) -> void:
+func add_frames(new_frames: Array, indices: Array) -> void:  # indices should be in ascending order
 	assert(self == Global.current_project) # TODO: Remove (Things like calling project_frame/layer_added may need to do a check if its the current project if this fails)
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
-	frames.insert(index, frame)
-	# TODO: These may need an if self == Global.current_project depending on use
-	Global.animation_timeline.project_frame_added(index)
+	for i in range(new_frames.size()):
+		frames.insert(indices[i], new_frames[i])
+		Global.animation_timeline.project_frame_added(indices[i])
 	# Update the frames and frame buttons:
 	for f in range(frames.size()):
 		Global.frame_ids.get_child(f).frame = f
@@ -806,13 +806,15 @@ func add_frame(frame: Frame, index: int) -> void:
 			layer_cel_container.get_child(f).button_setup()
 
 
-func remove_frame(index: int) -> void:
+func remove_frames(indices: Array) -> void:  # indices should be in ascending order
 	Global.canvas.selection.transform_content_confirm()
 	selected_cels.clear()
 	# TODO: If this messes up selection, would doing multiple here help?
 	# TODO: Could one half of cel linking and animation tags be included in the add or remove_frame functions? (ie: removing works, but adding doesn't?)
-	frames.remove(index)
-	Global.animation_timeline.project_frame_removed(index)
+	for i in range(indices.size()):
+		# With each removed index, future indices need to be lowered, so subtract by i
+		frames.remove(indices[i] - i)
+		Global.animation_timeline.project_frame_removed(indices[i] - i)
 	# Update the frames and frame buttons:
 	for f in range(frames.size()):
 		Global.frame_ids.get_child(f).frame = f
@@ -896,7 +898,7 @@ func remove_layer(index: int) -> void:
 	_toggle_layer_buttons_layers()
 
 
-# from_indices and to_indicies should start from the lowest index, and go up
+# from_indices and to_indicies should be in ascending order
 func move_layers(from_indices: Array, to_indices: Array, to_parents: Array) -> void:
 	# TODO: it may be good to do a test run with using loops of add/remove_layer instead of using move_layers
 	# TODO: to_parents could just be a single for now, but then how should move_layers be named?

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -492,17 +492,16 @@ func _layer_changed(value: int) -> void:
 func _toggle_layer_buttons() -> void:
 	if layers.empty() or current_layer >= layers.size():
 		return
-	# The size of the current layer (1) plus its children:
-	var current_layer_size: int = 1 + layers[current_layer].get_children_recursive().size()
+	var child_count: int = layers[current_layer].get_children_recursive().size()
 
 	Global.disable_button(Global.remove_layer_button,
 		layers[current_layer].is_locked_in_hierarchy()
-		or layers.size() == current_layer_size
+		or layers.size() == child_count + 1
 	)
 	Global.disable_button(Global.move_up_layer_button, current_layer == layers.size() - 1)
-	Global.disable_button(Global.move_down_layer_button, current_layer == current_layer_size - 1)
+	Global.disable_button(Global.move_down_layer_button, current_layer == child_count)
 	Global.disable_button(Global.merge_down_layer_button,
-		current_layer == current_layer_size - 1
+		current_layer == child_count
 		or layers[current_layer] is GroupLayer
 		or layers[current_layer - 1] is GroupLayer
 	)

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -26,7 +26,7 @@ func _ready() -> void:
 	Global.current_project.layers[0].project = Global.current_project
 	Global.current_project.frames.append(Global.current_project.new_empty_frame())
 	Global.animation_timeline.project_changed() # TODO R2: would it be a good idea to remove this, and the intial buttons back into the timeiline scene?
-
+	Global.current_project.toggle_frame_buttons()
 	# TODO R3: I Think this line should be safe to remove: (calling setter, already called when appending the layer)
 #	Global.current_project.layers = Global.current_project.layers
 

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -27,8 +27,6 @@ func _ready() -> void:
 	Global.current_project.frames.append(Global.current_project.new_empty_frame())
 	Global.animation_timeline.project_changed()
 	Global.current_project.toggle_frame_buttons()
-	# TODO R4: I Think this line should be safe to remove: (calling setter, already called when appending the layer)
-#	Global.current_project.layers = Global.current_project.layers
 
 	Import.import_brushes(Global.directory_module.get_brushes_search_path_in_order())
 	Import.import_patterns(Global.directory_module.get_patterns_search_path_in_order())

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -22,11 +22,13 @@ func _ready() -> void:
 
 	Global.window_title = tr("untitled") + " - Pixelorama " + Global.current_version
 
-	Global.current_project.add_layer(PixelLayer.new(), 0, [])
-	var frame: Frame = Global.current_project.new_empty_frame()
-	Global.current_project.add_frame(frame, 0)
+	Global.current_project.layers.append(PixelLayer.new())
+	Global.current_project.layers[0].project = Global.current_project
+	Global.current_project.frames.append(Global.current_project.new_empty_frame())
+	Global.animation_timeline.project_changed()
+
 	# TODO: I Think this line should be safe to remove: (calling setter)
-	Global.current_project.layers = Global.current_project.layers
+#	Global.current_project.layers = Global.current_project.layers
 
 	Import.import_brushes(Global.directory_module.get_brushes_search_path_in_order())
 	Import.import_patterns(Global.directory_module.get_patterns_search_path_in_order())

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -25,9 +25,9 @@ func _ready() -> void:
 	Global.current_project.layers.append(PixelLayer.new())
 	Global.current_project.layers[0].project = Global.current_project
 	Global.current_project.frames.append(Global.current_project.new_empty_frame())
-	Global.animation_timeline.project_changed()
+	Global.animation_timeline.project_changed() # TODO R: would it be a good idea to remove this, and the intial buttons back into the timeiline scene?
 
-	# TODO: I Think this line should be safe to remove: (calling setter)
+	# TODO R: I Think this line should be safe to remove: (calling setter)
 #	Global.current_project.layers = Global.current_project.layers
 
 	Import.import_brushes(Global.directory_module.get_brushes_search_path_in_order())

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -25,9 +25,9 @@ func _ready() -> void:
 	Global.current_project.layers.append(PixelLayer.new())
 	Global.current_project.layers[0].project = Global.current_project
 	Global.current_project.frames.append(Global.current_project.new_empty_frame())
-	Global.animation_timeline.project_changed() # TODO R: would it be a good idea to remove this, and the intial buttons back into the timeiline scene?
+	Global.animation_timeline.project_changed() # TODO R2: would it be a good idea to remove this, and the intial buttons back into the timeiline scene?
 
-	# TODO R: I Think this line should be safe to remove: (calling setter)
+	# TODO R3: I Think this line should be safe to remove: (calling setter)
 #	Global.current_project.layers = Global.current_project.layers
 
 	Import.import_brushes(Global.directory_module.get_brushes_search_path_in_order())

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -27,7 +27,7 @@ func _ready() -> void:
 	Global.current_project.frames.append(Global.current_project.new_empty_frame())
 	Global.animation_timeline.project_changed() # TODO R2: would it be a good idea to remove this, and the intial buttons back into the timeiline scene?
 
-	# TODO R3: I Think this line should be safe to remove: (calling setter)
+	# TODO R3: I Think this line should be safe to remove: (calling setter, already called when appending the layer)
 #	Global.current_project.layers = Global.current_project.layers
 
 	Import.import_brushes(Global.directory_module.get_brushes_search_path_in_order())

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -27,7 +27,7 @@ func _ready() -> void:
 	Global.current_project.frames.append(Global.current_project.new_empty_frame())
 	Global.animation_timeline.project_changed()
 	Global.current_project.toggle_frame_buttons()
-	# TODO R3: I Think this line should be safe to remove: (calling setter, already called when appending the layer)
+	# TODO R4: I Think this line should be safe to remove: (calling setter, already called when appending the layer)
 #	Global.current_project.layers = Global.current_project.layers
 
 	Import.import_brushes(Global.directory_module.get_brushes_search_path_in_order())

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -25,7 +25,7 @@ func _ready() -> void:
 	Global.current_project.layers.append(PixelLayer.new())
 	Global.current_project.layers[0].project = Global.current_project
 	Global.current_project.frames.append(Global.current_project.new_empty_frame())
-	Global.animation_timeline.project_changed() # TODO R2: would it be a good idea to remove this, and the intial buttons back into the timeiline scene?
+	Global.animation_timeline.project_changed()
 	Global.current_project.toggle_frame_buttons()
 	# TODO R3: I Think this line should be safe to remove: (calling setter, already called when appending the layer)
 #	Global.current_project.layers = Global.current_project.layers

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -22,9 +22,10 @@ func _ready() -> void:
 
 	Global.window_title = tr("untitled") + " - Pixelorama " + Global.current_version
 
-	Global.current_project.layers.append(PixelLayer.new())
+	Global.current_project.add_layer(PixelLayer.new(), 0, [])
 	var frame: Frame = Global.current_project.new_empty_frame()
-	Global.current_project.frames.append(frame)
+	Global.current_project.add_frame(frame, 0)
+	# TODO: I Think this line should be safe to remove: (calling setter)
 	Global.current_project.layers = Global.current_project.layers
 
 	Import.import_brushes(Global.directory_module.get_brushes_search_path_in_order())

--- a/src/Tools/BaseTool.gd
+++ b/src/Tools/BaseTool.gd
@@ -88,7 +88,7 @@ func _get_selected_draw_images() -> Array:  # Array of Images
 	var images := []
 	var project: Project = Global.current_project
 	for cel_index in project.selected_cels:
-		# TODO: Check this: (BaseCel is fine because it asks can_layer_get_drawn)
+		# TODO H: Check this: (BaseCel is fine because it asks can_layer_get_drawn)
 		var cel: BaseCel = project.frames[cel_index[0]].cels[cel_index[1]]
 		if project.layers[cel_index[1]].can_layer_get_drawn():
 			images.append(cel.image)

--- a/src/UI/Canvas/Canvas.gd
+++ b/src/UI/Canvas/Canvas.gd
@@ -132,12 +132,13 @@ func update_selected_cels_textures(project: Project = Global.current_project) ->
 			var current_cel: PixelCel = project.frames[frame_index].cels[layer_index]
 			current_cel.image_texture.set_data(current_cel.image)
 
-			if project == Global.current_project:
-				var container_index = Global.frames_container.get_child_count() - 1 - layer_index
-				var layer_cel_container = Global.frames_container.get_child(container_index)
-				var cel_button = layer_cel_container.get_child(frame_index)
-				var cel_texture_rect: TextureRect = cel_button.find_node("CelTexture")
-				cel_texture_rect.texture = current_cel.image_texture
+			# TODO: This wasn't working anymore, but is it even needed? (Same as above)
+#			if project == Global.current_project:
+#				var container_index = Global.frames_container.get_child_count() - 1 - layer_index
+#				var layer_cel_container = Global.frames_container.get_child(container_index)
+#				var cel_button = layer_cel_container.get_child(frame_index)
+#				var cel_texture_rect: TextureRect = cel_button.find_node("CelTexture")
+#				cel_texture_rect.texture = current_cel.image_texture
 
 
 func refresh_onion() -> void:

--- a/src/UI/Canvas/Canvas.gd
+++ b/src/UI/Canvas/Canvas.gd
@@ -110,7 +110,7 @@ func update_texture(layer_i: int, frame_i := -1, project: Project = Global.curre
 		frame_i = project.current_frame
 
 	if frame_i < project.frames.size() and layer_i < project.layers.size():
-		# TODO: make sure this is right:
+		# TODO H: make sure this is right:
 		var current_cel: PixelCel = project.frames[frame_i].cels[layer_i]
 		current_cel.image_texture.set_data(current_cel.image)
 
@@ -128,11 +128,11 @@ func update_selected_cels_textures(project: Project = Global.current_project) ->
 		var frame_index: int = cel_index[0]
 		var layer_index: int = cel_index[1]
 		if frame_index < project.frames.size() and layer_index < project.layers.size():
-			# TODO: make sure this is right:
+			# TODO H: make sure this is right:
 			var current_cel: PixelCel = project.frames[frame_index].cels[layer_index]
 			current_cel.image_texture.set_data(current_cel.image)
 
-			# TODO: This wasn't working anymore, but is it even needed? (Same as above)
+			# TODO H: This wasn't working anymore, but is it even needed? (Same as above)
 #			if project == Global.current_project:
 #				var container_index = Global.frames_container.get_child_count() - 1 - layer_index
 #				var layer_cel_container = Global.frames_container.get_child(container_index)

--- a/src/UI/Dialogs/CreateNewImage.gd
+++ b/src/UI/Dialogs/CreateNewImage.gd
@@ -109,9 +109,9 @@ func _on_CreateNewImage_confirmed() -> void:
 
 	var new_project := Project.new([], proj_name, Vector2(width, height).floor())
 	new_project.layers.append(PixelLayer.new())
+	new_project.layers[0].project = new_project
 	new_project.fill_color = fill_color
-	var frame: Frame = new_project.new_empty_frame()
-	new_project.frames.append(frame)
+	new_project.frames.append(new_project.new_empty_frame())
 	Global.projects.append(new_project)
 	Global.tabs.current_tab = Global.tabs.get_tab_count() - 1
 	Global.canvas.camera_zoom()

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -410,12 +410,12 @@ func _on_PlayBackwards_toggled(button_pressed: bool) -> void:
 
 	play_animation(button_pressed, false)
 
-
+# Called on each frame of the animation
 func _on_AnimationTimer_timeout() -> void:
 	if first_frame == last_frame:
 		Global.play_forward.pressed = false
 		Global.play_backwards.pressed = false
-		$AnimationTimer.stop()
+		Global.animation_timer.stop()
 		return
 
 	Global.canvas.selection.transform_content_confirm()
@@ -620,6 +620,7 @@ func _on_AddGroup_pressed() -> void:
 
 
 func _on_CloneLayer_pressed() -> void:
+	# TODO H: clone children along with layer
 	var project: Project = Global.current_project
 	var l: BaseLayer = project.layers[project.current_layer].copy()
 	l.name = str(project.layers[project.current_layer].name, " (", tr("copy"), ")")
@@ -799,7 +800,8 @@ func _on_OnionSkinningSettings_popup_hide() -> void:
 
 func project_changed() -> void:
 	var project: Project = Global.current_project
-	# These must be removed from tree immediately to not mess up the indices of the new buttons:
+	# These must be removed from tree immediately to not mess up the indices of
+	# the new buttons, so use either free or queue_free + parent.remove_child
 	for child in Global.layers_container.get_children():
 		child.free()
 	for child in Global.frame_ids.get_children():

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -831,12 +831,6 @@ func project_changed() -> void:
 		Global.frame_ids.add_child(button)
 		Global.frame_ids.move_child(button, f)
 
-	# TODO: May not be needed, depending on other changes to selection
-#	var current_layer_button = Global.layers_container.get_child(
-#		Global.layers_container.get_child_count() - 1 - project.current_layer
-#	)
-#	current_layer_button.pressed = true
-
 	# TODO: Remove an inline what's needed here if this isn't used anywhere else:
 	Global.current_project._update_animation_timeline_selection()
 

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -878,8 +878,6 @@ func project_layer_added(layer: int) -> void:
 		project.layers[layer].set_name_to_default(layer)
 
 	var layer_cel_container := HBoxContainer.new()
-	# TODO R4: Is there any need for a name (and why is it LAYERSSS in one place, and FRAMESS in another?)
-	layer_cel_container.name = "LAYERSSS " + str(layer)
 	for f in range(project.frames.size()):
 		var cel_button = project.frames[f].cels[layer].create_cel_button()
 		cel_button.frame = f

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -300,12 +300,16 @@ func copy_frames(frames := []) -> void:
 		copied_frames.append(new_frame)
 
 		var prev_frame: Frame = project.frames[frame]
-		for cel in prev_frame.cels:
-			new_frame.cels.append(cel.copy())
 
 		new_frame.duration = prev_frame.duration
 		for l_i in range(new_layers.size()):
-			if new_layers[l_i].get("new_cels_linked"):  # If the link button is pressed
+			# If the layer has new_cels_linked variable, and its true
+			var new_cels_linked: bool = new_layers[l_i].get("new_cels_linked")
+
+			# Copy the cel, create new cel content if new cels aren't linked
+			new_frame.cels.append(new_layers[l_i].copy_cel(frame, !new_cels_linked))
+
+			if new_cels_linked:  # If the link button is pressed
 				new_layers[l_i].linked_cels.append(new_frame)
 				new_frame.cels[l_i].image = new_layers[l_i].linked_cels[0].cels[l_i].image
 				new_frame.cels[l_i].image_texture = new_layers[l_i].linked_cels[0].cels[l_i].image_texture
@@ -624,11 +628,7 @@ func _on_CloneLayer_pressed() -> void:
 	var project: Project = Global.current_project
 	var l: BaseLayer = project.layers[project.current_layer].copy()
 	l.name = str(project.layers[project.current_layer].name, " (", tr("copy"), ")")
-	var cels := []
-	for f in project.frames:
-		cels.append(f.cels[project.current_layer].copy())
-
-	# TODO R0: Copies don't have linked cels properly set up...
+	var cels: Array = project.layers[project.current_layer].copy_all_cels(true)
 
 	project.undos += 1
 	project.undo_redo.create_action("Add Layer")

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -13,7 +13,7 @@ var past_above_canvas := true
 var future_above_canvas := true
 
 var frame_button_node = preload("res://src/UI/Timeline/FrameButton.tscn")
-# TODO: May remove some of these:
+# TODO R: May remove some of these:
 var pixel_layer_button_node = preload("res://src/UI/Timeline/PixelLayerButton.tscn")
 var group_layer_button_node = preload("res://src/UI/Timeline/GroupLayerButton.tscn")
 var pixel_cel_button_node = preload("res://src/UI/Timeline/PixelCelButton.tscn")
@@ -43,7 +43,7 @@ func _ready() -> void:
 	find_node("EndSpacer").size_flags_horizontal = SIZE_EXPAND_FILL
 	timeline_scroll.size_flags_horizontal = SIZE_FILL
 
-# TODO: See if these two should be kept or done another way:
+# TODO L: See if these two should be kept or done another way:
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_DRAG_END:
 		drag_highlight.hide()
@@ -267,7 +267,7 @@ func delete_frames(frames := []) -> void:
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 	project.undo_redo.commit_action()
 
-# TODO: Is there any point in frame here being a func parameter? Same with _on_DeleteFrame_presssed above (and maybe more)
+# TODO L: Is there any point in frame here being a func parameter? Same with _on_DeleteFrame_presssed above (and maybe more)
 func _on_CopyFrame_pressed(frame := -1) -> void:
 	var frames := []
 	for cel in Global.current_project.selected_cels:
@@ -345,7 +345,6 @@ func _on_FrameTagButton_pressed() -> void:
 
 
 func _on_MoveLeft_pressed() -> void:
-	# TODO: Do these
 	var frame: int = Global.current_project.current_frame
 	if frame == 0:
 		return
@@ -582,9 +581,8 @@ func _on_FuturePlacement_item_selected(index: int) -> void:
 
 
 func add_layer(is_new := true) -> void:
-	# TODO: Duplicate functionality should probably be split out to allow for different layer types
-	# TODO: Bug where adding a layer isn't selecting the new layer?
-	Global.canvas.selection.transform_content_confirm() # TODO: Figure out once and for all, do these belong here, or in the project reversable functions (where these will be called on undo as well)
+	# TODO R: Duplicate functionality should probably be split out to allow for different layer types
+	Global.canvas.selection.transform_content_confirm() # TODO R: Figure out once and for all, do these belong here, or in the project reversable functions (where these will be called on undo as well)
 	var project: Project = Global.current_project
 	var l : BaseLayer
 	if is_new:
@@ -602,7 +600,7 @@ func add_layer(is_new := true) -> void:
 		else:  # Clone layer
 			cels.append(f.cels[project.current_layer].copy())
 
-	# TODO: Copies don't have linked cels properly set up...
+	# TODO R: Copies don't have linked cels properly set up...
 
 	project.undos += 1
 	project.undo_redo.create_action("Add Layer")
@@ -661,7 +659,7 @@ func _on_RemoveLayer_pressed() -> void:
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 	project.undo_redo.commit_action()
 
-# TODO: Refactor this (maybe completely remove)
+# TODO L: Refactor this (maybe completely remove)
 func change_layer_order(rate: int) -> void:
 	var change = Global.current_project.current_layer + rate
 
@@ -693,7 +691,7 @@ func change_layer_order(rate: int) -> void:
 	Global.current_project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	Global.current_project.undo_redo.commit_action()
 
-# TODO: Does this need to be part of the refactor?
+# TODO R: Does this need to be part of the refactor?
 func _on_MergeDownLayer_pressed() -> void:
 	var new_layers: Array = Global.current_project.duplicate_layers()
 
@@ -786,8 +784,8 @@ func _on_OnionSkinningSettings_popup_hide() -> void:
 
 
 func project_changed() -> void:
-	var project: Project = Global.current_project # TODO: maybe pass in instead?
-	# TODO: Could using queue_free rather than free (or remove and queue_free) actually cause bugs?
+	var project: Project = Global.current_project # TODO R: maybe pass in instead?
+	# TODO R: Could using queue_free rather than free (or remove and queue_free) actually cause bugs?
 	for child in Global.layers_container.get_children():
 		child.queue_free()
 	for child in Global.frame_ids.get_children():
@@ -803,12 +801,12 @@ func project_changed() -> void:
 		Global.frame_ids.add_child(button)
 		Global.frame_ids.move_child(button, f)
 
-	# TODO: Remove an inline what's needed here if this isn't used anywhere else:
+	# TODO R: Remove and inline what's needed here if this isn't used anywhere else:
 	Global.current_project._update_animation_timeline_selection()
 
 
 func project_frame_added(frame: int) -> void:
-	var project: Project = Global.current_project # TODO: maybe pass in instead?
+	var project: Project = Global.current_project # TODO R: maybe pass in instead?
 	var button: Button = frame_button_node.instance()
 	button.frame = frame
 	Global.frame_ids.add_child(button)
@@ -832,17 +830,17 @@ func project_frame_removed(frame: int) -> void:
 
 
 func project_layer_added(layer: int) -> void:
-	var project: Project = Global.current_project # TODO: maybe pass in instead?
-	# TODO: should probably have a "layer" variable... (to many project.layers[layer])...
+	var project: Project = Global.current_project
+	# TODO R: should probably have a "layer" variable... (to many project.layers[layer])...
 	#		...or refactor things so less of this code is needed here.
-	# TODO: Could this function be organized in a better way?
+	# TODO R: Could this function be organized in a better way?
 	var layer_button: LayerButton
 	if project.layers[layer] is PixelLayer:
 		layer_button = pixel_layer_button_node.instance()
 	elif project.layers[layer] is GroupLayer:
 		layer_button = group_layer_button_node.instance()
-	layer_button.layer = layer # TODO: See if needed
-	if project.layers[layer].name == "": # TODO: This probably could be somewhere else...
+	layer_button.layer = layer # TODO R: See if needed
+	if project.layers[layer].name == "": # TODO R: This probably could be somewhere else... add_layer(s) in project?
 		project.layers[layer].name = project.layers[layer].get_default_name(layer)
 
 	Global.layers_container.add_child(layer_button)
@@ -850,14 +848,14 @@ func project_layer_added(layer: int) -> void:
 	Global.layers_container.move_child(layer_button, count - 1 - layer)
 
 	var layer_cel_container := HBoxContainer.new()
-	# TODO: Is there any need for a name (and why is it LAYERSSS in one place, and FRAMESS in another?)
+	# TODO R: Is there any need for a name (and why is it LAYERSSS in one place, and FRAMESS in another?)
 	layer_cel_container.name = "LAYERSSS " + str(layer)
 	Global.frames_container.add_child(layer_cel_container)
 	Global.frames_container.move_child(layer_cel_container, count - 1 - layer)
 	for f in range(project.frames.size()):
 		var cel_button = project.frames[f].cels[layer].create_cel_button()
 		cel_button.frame = f
-		cel_button.layer = layer# - 1 # TODO: See if needed
+		cel_button.layer = layer# - 1 # TODO R: See if needed
 		layer_cel_container.add_child(cel_button)
 
 	layer_button.visible = Global.current_project.layers[layer].is_expanded_in_hierarchy()
@@ -877,7 +875,7 @@ func project_cel_added(frame: int, layer: int) -> void:
 	var cel_button = Global.current_project.frames[frame].cels[layer].create_cel_button()
 	cel_button.frame = frame
 	cel_button.layer = layer
-	# TODO: Do we need stuff like this for selection?
+	# TODO R: Do we need stuff like this for selection?
 #	cel_button.pressed = Global.current_project.selected_cels.has([frame, layer])
 	container.add_child(cel_button)
 	container.move_child(cel_button, frame)

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -13,6 +13,7 @@ var past_above_canvas := true
 var future_above_canvas := true
 
 var frame_button_node = preload("res://src/UI/Timeline/FrameButton.tscn")
+# TODO: May remove some of these:
 var pixel_layer_button_node = preload("res://src/UI/Timeline/PixelLayerButton.tscn")
 var group_layer_button_node = preload("res://src/UI/Timeline/GroupLayerButton.tscn")
 var pixel_cel_button_node = preload("res://src/UI/Timeline/PixelCelButton.tscn")
@@ -827,24 +828,23 @@ func project_changed() -> void:
 	for f in range(project.frames.size()):
 		var button: Button = frame_button_node.instance()
 		button.frame = f
-		button.rect_min_size.x = Global.animation_timeline.cel_size
-		button.text = str(f + 1)
 		Global.frame_ids.add_child(button)
 		Global.frame_ids.move_child(button, f)
 
 	# TODO: May not be needed, depending on other changes to selection
-	var current_layer_button = Global.layers_container.get_child(
-		Global.layers_container.get_child_count() - 1 - project.current_layer
-	)
-	current_layer_button.pressed = true
+#	var current_layer_button = Global.layers_container.get_child(
+#		Global.layers_container.get_child_count() - 1 - project.current_layer
+#	)
+#	current_layer_button.pressed = true
+
+	# TODO: Remove an inline what's needed here if this isn't used anywhere else:
+	Global.current_project._update_animation_timeline_selection()
 
 
 func project_frame_added(frame: int) -> void:
 	var project: Project = Global.current_project # TODO: maybe pass in instead?
 	var button: Button = frame_button_node.instance()
 	button.frame = frame
-	button.rect_min_size.x = Global.animation_timeline.cel_size
-	button.text = str(frame + 1)
 	Global.frame_ids.add_child(button)
 	Global.frame_ids.move_child(button, frame)
 
@@ -856,6 +856,7 @@ func project_frame_added(frame: int) -> void:
 		container.add_child(cel_button)
 		container.move_child(cel_button, frame)
 		layer += 1
+	# TODO: Adding a frame with multiple layers results in the cels being put backwards!
 
 
 func project_frame_removed(frame: int) -> void:

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -850,7 +850,7 @@ func project_layer_added(layer: int) -> void:
 
 	var layer_button: LayerButton = project.layers[layer].create_layer_button()
 	layer_button.layer = layer
-	if project.layers[layer].name == "": # TODO R1: This probably could be somewhere else... add_layer(s) in project?
+	if project.layers[layer].name == "":
 		project.layers[layer].set_name_to_default(layer)
 
 	var layer_cel_container := HBoxContainer.new()

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -878,7 +878,7 @@ func project_layer_added(layer: int) -> void:
 		project.layers[layer].set_name_to_default(layer)
 
 	var layer_cel_container := HBoxContainer.new()
-	for f in range(project.frames.size()):
+	for f in project.frames.size():
 		var cel_button = project.frames[f].cels[layer].create_cel_button()
 		cel_button.frame = f
 		cel_button.layer = layer

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -657,7 +657,6 @@ func _on_RemoveLayer_pressed() -> void:
 
 	project.undos += 1
 	project.undo_redo.create_action("Remove Layer")
-	# TODO R3: what should be the new current layer?
 	project.undo_redo.add_do_property(project, "current_layer", max(indices[0] - 1, 0))
 	project.undo_redo.add_undo_property(project, "current_layer", project.current_layer)
 	project.undo_redo.add_do_method(project, "remove_layers", indices)
@@ -801,7 +800,7 @@ func _on_OnionSkinningSettings_popup_hide() -> void:
 
 
 func project_changed() -> void:
-	var project: Project = Global.current_project # TODO R3: maybe pass in instead?
+	var project: Project = Global.current_project
 	# These must be removed from tree immediately to not mess up the indices of the new buttons:
 	for child in Global.layers_container.get_children():
 		child.free()
@@ -817,12 +816,12 @@ func project_changed() -> void:
 		button.frame = f
 		Global.frame_ids.add_child(button)
 
-	# TODO R3: Remove and inline what's needed here if this isn't used anywhere else:
+	# TODO R4: Remove and inline what's needed here if this isn't used anywhere else:
 	Global.current_project._update_animation_timeline_selection()
 
 
 func project_frame_added(frame: int) -> void:
-	var project: Project = Global.current_project # TODO R3: maybe pass in instead?
+	var project: Project = Global.current_project
 	var button: Button = frame_button_node.instance()
 	button.frame = frame
 	Global.frame_ids.add_child(button)

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -521,7 +521,7 @@ func play_animation(play: bool, forward_dir: bool) -> void:
 
 
 func _on_NextFrame_pressed() -> void:
-	Global.canvas.selection.transform_content_confirm() # TODO R4: These may be safe to remove, (frame_changed in project calls it)
+	Global.canvas.selection.transform_content_confirm() # TODO R3: These may be safe to remove, (frame_changed in project calls it)
 	Global.current_project.selected_cels.clear() # TODO NOTE: ^^ Though clearing the selected cels may mess that up.
 	if Global.current_project.current_frame < Global.current_project.frames.size() - 1:
 		Global.current_project.current_frame += 1
@@ -801,6 +801,9 @@ func _on_OnionSkinningSettings_popup_hide() -> void:
 	Global.can_draw = true
 
 
+# Methods to update the UI in response to changes in the current project
+
+
 func project_changed() -> void:
 	var project: Project = Global.current_project
 	# These must be removed from tree immediately to not mess up the indices of
@@ -819,7 +822,7 @@ func project_changed() -> void:
 		button.frame = f
 		Global.frame_ids.add_child(button)
 
-	# TODO R4: Remove and inline what's needed here if this isn't used anywhere else:
+	# TODO R3: Remove and inline what's needed here if this isn't used anywhere else:
 	Global.current_project._update_animation_timeline_selection()
 
 
@@ -856,7 +859,7 @@ func project_layer_added(layer: int) -> void:
 		project.layers[layer].set_name_to_default(layer)
 
 	var layer_cel_container := HBoxContainer.new()
-	# TODO R3: Is there any need for a name (and why is it LAYERSSS in one place, and FRAMESS in another?)
+	# TODO R4: Is there any need for a name (and why is it LAYERSSS in one place, and FRAMESS in another?)
 	layer_cel_container.name = "LAYERSSS " + str(layer)
 	for f in range(project.frames.size()):
 		var cel_button = project.frames[f].cels[layer].create_cel_button()

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -181,9 +181,6 @@ func add_frame() -> void:
 	project.undo_redo.add_do_property(project, "current_frame", project.current_frame + 1)
 	project.undo_redo.add_undo_property(project, "current_frame", project.current_frame)
 	project.undo_redo.commit_action()
-	# TODO: Remove after testing:
-	print(project.selected_cels)
-	print(project.current_frame)
 
 
 func _on_DeleteFrame_pressed(frame := -1) -> void:
@@ -689,7 +686,7 @@ func _on_RemoveLayer_pressed() -> void:
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 	project.undo_redo.commit_action()
 
-# TODO: Refactor this (probably completely remove)
+# TODO: Refactor this (maybe completely remove)
 func change_layer_order(rate: int) -> void:
 	var change = Global.current_project.current_layer + rate
 
@@ -721,7 +718,7 @@ func change_layer_order(rate: int) -> void:
 	Global.current_project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	Global.current_project.undo_redo.commit_action()
 
-
+# TODO: Does this need to be part of the refactor?
 func _on_MergeDownLayer_pressed() -> void:
 	var new_layers: Array = Global.current_project.duplicate_layers()
 

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -415,6 +415,8 @@ func _on_PlayBackwards_toggled(button_pressed: bool) -> void:
 
 func _on_AnimationTimer_timeout() -> void:
 	if first_frame == last_frame:
+		Global.play_forward.pressed = false
+		Global.play_backwards.pressed = false
 		$AnimationTimer.stop()
 		return
 

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -139,6 +139,7 @@ func add_frame() -> void:
 	var new_layers: Array = project.duplicate_layers()
 
 	for l_i in range(new_layers.size()):
+		# TODO H: Make sure this works with groups (Check out copy frames):
 		if new_layers[l_i].new_cels_linked:  # If the link button is pressed
 			new_layers[l_i].linked_cels.append(frame)
 			frame.cels[l_i].image = new_layers[l_i].linked_cels[0].cels[l_i].image
@@ -622,7 +623,6 @@ func _on_AddGroup_pressed() -> void:
 
 
 func _on_CloneLayer_pressed() -> void:
-	# TODO L: Multiple layer support here would be nice
 	Global.canvas.selection.transform_content_confirm()
 
 	var project: Project = Global.current_project
@@ -730,7 +730,7 @@ func _on_MergeDownLayer_pressed() -> void:
 	project.undos += 1
 	project.undo_redo.create_action("Merge Layer")
 
-	# TODO R0: When there is a group layer/cel present in the tree, merging down Pixel Layers
+	# TODO H: When there is a group layer/cel present in the tree, merging down Pixel Layers
 	#			 doesn't get the texture updated. (Image is updated though, doing something else will update texture)
 
 	for f in project.frames:

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -891,4 +891,5 @@ func project_cel_removed(frame: int, layer: int) -> void:
 	var container := Global.frames_container.get_child(
 		Global.frames_container.get_child_count() - 1 - layer
 	)
-	container.get_child(frame).free()
+	container.get_child(frame).queue_free()
+	container.remove_child(container.get_child(frame))

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -521,8 +521,8 @@ func play_animation(play: bool, forward_dir: bool) -> void:
 
 
 func _on_NextFrame_pressed() -> void:
-	Global.canvas.selection.transform_content_confirm() # TODO R3: These may be safe to remove, (frame_changed in project calls it)
-	Global.current_project.selected_cels.clear() # TODO NOTE: ^^ Though clearing the selected cels may mess that up.
+	Global.canvas.selection.transform_content_confirm()
+	Global.current_project.selected_cels.clear()
 	if Global.current_project.current_frame < Global.current_project.frames.size() - 1:
 		Global.current_project.current_frame += 1
 
@@ -822,8 +822,27 @@ func project_changed() -> void:
 		button.frame = f
 		Global.frame_ids.add_child(button)
 
-	# TODO R3: Remove and inline what's needed here if this isn't used anywhere else:
-	Global.current_project._update_animation_timeline_selection()
+	# Press selected cel/frame/layer buttons
+	for cel in project.selected_cels:
+		var frame: int = cel[0]
+		var layer: int = cel[1]
+		if frame < Global.frame_ids.get_child_count():
+			var frame_button: BaseButton = Global.frame_ids.get_child(frame)
+			frame_button.pressed = true
+
+		var container_child_count: int = Global.frames_container.get_child_count()
+		if layer < container_child_count:
+			var container = Global.frames_container.get_child(
+				container_child_count - 1 - layer
+			)
+			if frame < container.get_child_count():
+				var cel_button = container.get_child(frame)
+				cel_button.pressed = true
+
+			var layer_button = Global.layers_container.get_child(
+				container_child_count - 1 - layer
+			)
+			layer_button.pressed = true
 
 
 func project_frame_added(frame: int) -> void:

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -848,29 +848,28 @@ func project_frame_removed(frame: int) -> void:
 func project_layer_added(layer: int) -> void:
 	var project: Project = Global.current_project
 
-	# TODO R1: Could this function be organized in a better way?
 	var layer_button: LayerButton = project.layers[layer].create_layer_button()
-	layer_button.layer = layer # TODO R1: See if needed
+	layer_button.layer = layer
 	if project.layers[layer].name == "": # TODO R1: This probably could be somewhere else... add_layer(s) in project?
 		project.layers[layer].name = project.layers[layer].get_default_name(layer)
-
-	Global.layers_container.add_child(layer_button)
-	var count := Global.layers_container.get_child_count()
-	Global.layers_container.move_child(layer_button, count - 1 - layer)
 
 	var layer_cel_container := HBoxContainer.new()
 	# TODO R3: Is there any need for a name (and why is it LAYERSSS in one place, and FRAMESS in another?)
 	layer_cel_container.name = "LAYERSSS " + str(layer)
-	Global.frames_container.add_child(layer_cel_container)
-	Global.frames_container.move_child(layer_cel_container, count - 1 - layer)
 	for f in range(project.frames.size()):
 		var cel_button = project.frames[f].cels[layer].create_cel_button()
 		cel_button.frame = f
-		cel_button.layer = layer# - 1 # TODO R1: See if needed
+		cel_button.layer = layer
 		layer_cel_container.add_child(cel_button)
 
 	layer_button.visible = Global.current_project.layers[layer].is_expanded_in_hierarchy()
 	layer_cel_container.visible = layer_button.visible
+
+	Global.layers_container.add_child(layer_button)
+	var count := Global.layers_container.get_child_count()
+	Global.layers_container.move_child(layer_button, count - 1 - layer)
+	Global.frames_container.add_child(layer_cel_container)
+	Global.frames_container.move_child(layer_cel_container, count - 1 - layer)
 
 
 func project_layer_removed(layer: int) -> void:

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -287,7 +287,7 @@ func copy_frames(frames := []) -> void:
 
 	var new_layers: Array = project.duplicate_layers()
 	var copied_frames := []
-	var copied_indices := []
+	var copied_indices := range(frames[-1] + 1, frames[-1] + 1 + frames.size())
 
 	var new_animation_tags := project.animation_tags.duplicate()
 	# Loop through the tags to create new classes for them, so that they won't be the same
@@ -300,12 +300,9 @@ func copy_frames(frames := []) -> void:
 			new_animation_tags[i].to
 		)
 
-	for i in frames.size():
-		var frame = frames[i]
+	for frame in frames:
 		var new_frame := Frame.new()
 		copied_frames.append(new_frame)
-		# Indices should start after the last frame to copy, and go up for each iteration:
-		copied_indices.append(frames[-1] + 1 + i)
 
 		var prev_frame: Frame = project.frames[frame]
 		for cel in prev_frame.cels:

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -625,7 +625,7 @@ func _on_CloneLayer_pressed() -> void:
 	var project: Project = Global.current_project
 	var l: BaseLayer = project.layers[project.current_layer].copy()
 	l.name = str(project.layers[project.current_layer].name, " (", tr("copy"), ")")
-	var cels: Array = project.layers[project.current_layer].copy_all_cels(true)
+	var cels: Array = project.layers[project.current_layer].copy_all_cels()
 
 	project.undos += 1
 	project.undo_redo.create_action("Add Layer")

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -851,7 +851,7 @@ func project_layer_added(layer: int) -> void:
 	var layer_button: LayerButton = project.layers[layer].create_layer_button()
 	layer_button.layer = layer
 	if project.layers[layer].name == "": # TODO R1: This probably could be somewhere else... add_layer(s) in project?
-		project.layers[layer].name = project.layers[layer].get_default_name(layer)
+		project.layers[layer].set_name_to_default(layer)
 
 	var layer_cel_container := HBoxContainer.new()
 	# TODO R3: Is there any need for a name (and why is it LAYERSSS in one place, and FRAMESS in another?)

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -168,10 +168,10 @@ func add_frame() -> void:
 	project.undo_redo.create_action("Add Frame")
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
-	project.undo_redo.add_do_method(project, "add_frames", [frame], [frame_add_index])
-	project.undo_redo.add_undo_method(project, "remove_frames", [frame_add_index])
 	project.undo_redo.add_do_property(project, "layers", new_layers)
 	project.undo_redo.add_undo_property(project, "layers", project.layers)
+	project.undo_redo.add_do_method(project, "add_frames", [frame], [frame_add_index])
+	project.undo_redo.add_undo_method(project, "remove_frames", [frame_add_index])
 	project.undo_redo.add_do_property(project, "animation_tags", new_animation_tags)
 	project.undo_redo.add_undo_property(project, "animation_tags", project.animation_tags)
 	project.undo_redo.add_do_property(project, "current_frame", project.current_frame + 1)
@@ -251,10 +251,10 @@ func delete_frames(frames := []) -> void:
 
 	project.undos += 1
 	project.undo_redo.create_action("Remove Frame")
-	project.undo_redo.add_do_method(project, "remove_frames", frames)
-	project.undo_redo.add_undo_method(project, "add_frames", frame_refs, frames)
 	project.undo_redo.add_do_property(project, "layers", new_layers)
 	project.undo_redo.add_undo_property(project, "layers", Global.current_project.layers)
+	project.undo_redo.add_do_method(project, "remove_frames", frames)
+	project.undo_redo.add_undo_method(project, "add_frames", frame_refs, frames)
 	project.undo_redo.add_do_property(project, "animation_tags", new_animation_tags)
 	project.undo_redo.add_undo_property(project, "animation_tags", project.animation_tags)
 	project.undo_redo.add_do_property(project, "current_frame", current_frame)
@@ -306,8 +306,9 @@ func copy_frames(frames := []) -> void:
 			# If the layer has new_cels_linked variable, and its true
 			var new_cels_linked: bool = new_layers[l_i].get("new_cels_linked")
 
+			# TODO R3: Make sure this is working:
 			# Copy the cel, create new cel content if new cels aren't linked
-			new_frame.cels.append(new_layers[l_i].copy_cel(frame, !new_cels_linked))
+			new_frame.cels.append(new_layers[l_i].copy_cel(frame, new_cels_linked))
 
 			if new_cels_linked:  # If the link button is pressed
 				new_layers[l_i].linked_cels.append(new_frame)
@@ -326,15 +327,13 @@ func copy_frames(frames := []) -> void:
 	project.undo_redo.create_action("Add Frame")
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
+	project.undo_redo.add_do_property(project, "layers", new_layers)
+	project.undo_redo.add_undo_property(project, "layers", project.layers)
 	project.undo_redo.add_do_method(project, "add_frames", copied_frames, copied_indices)
 	project.undo_redo.add_undo_method(project, "remove_frames", copied_indices)
-
 	project.undo_redo.add_do_property(project, "current_frame", frames[-1] + 1)
-	project.undo_redo.add_do_property(project, "layers", new_layers)
-	project.undo_redo.add_do_property(project, "animation_tags", new_animation_tags)
-
 	project.undo_redo.add_undo_property(project, "current_frame", frames[-1])
-	project.undo_redo.add_undo_property(project, "layers", project.layers)
+	project.undo_redo.add_do_property(project, "animation_tags", new_animation_tags)
 	project.undo_redo.add_undo_property(project, "animation_tags", project.animation_tags)
 	project.undo_redo.commit_action()
 

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -669,37 +669,56 @@ func _on_RemoveLayer_pressed() -> void:
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 	project.undo_redo.commit_action()
 
-# TODO L: Refactor this (maybe completely remove)
-func change_layer_order(rate: int) -> void:
-	var change = Global.current_project.current_layer + rate
 
-	var new_layers: Array = Global.current_project.layers.duplicate()
-	var temp = new_layers[Global.current_project.current_layer]
-	new_layers[Global.current_project.current_layer] = new_layers[change]
-	new_layers[change] = temp
-	Global.current_project.undo_redo.create_action("Change Layer Order")
-	for f in Global.current_project.frames:
-		var new_cels: Array = f.cels.duplicate()
-		var temp_canvas = new_cels[Global.current_project.current_layer]
-		new_cels[Global.current_project.current_layer] = new_cels[change]
-		new_cels[change] = temp_canvas
-		Global.current_project.undo_redo.add_do_property(f, "cels", new_cels)
-		Global.current_project.undo_redo.add_undo_property(f, "cels", f.cels)
+func change_layer_order(up: bool) -> void:
+	var project: Project = Global.current_project
+	var layer: BaseLayer = project.layers[project.current_layer]
+	var to_index = layer.index
+	var child_count = layer.get_children_recursive().size()
+	var from_indices := range(layer.index - child_count, layer.index + 1)
+	var from_parents := []
+	for l in from_indices:
+		from_parents.append(project.layers[l].parent)
+	var to_parents := from_parents.duplicate()
 
-	Global.current_project.undo_redo.add_do_property(
-		Global.current_project, "current_layer", change
-	)
-	Global.current_project.undo_redo.add_do_property(Global.current_project, "layers", new_layers)
-	Global.current_project.undo_redo.add_undo_property(
-		Global.current_project, "layers", Global.current_project.layers
-	)
-	Global.current_project.undo_redo.add_undo_property(
-		Global.current_project, "current_layer", Global.current_project.current_layer
-	)
+	if up:
+		var above_layer: BaseLayer = project.layers[project.current_layer + 1]
+		if layer.parent == above_layer: # Above is the parent, leave the parent
+			to_parents[-1] = above_layer.parent
+			to_index = layer.index + 1
+		elif layer.parent != above_layer.parent: # Above layer must be deeper in the hierarchy
+			to_parents[-1] = above_layer.parent # (this may be more than 1 level deeper)
+			while to_parents[-1].parent != layer.parent:
+				to_parents[-1]= to_parents[-1].parent # Incase we went multiple levels, drop extra
+		elif above_layer.accepts_child(layer):
+			to_parents[-1] = above_layer
+		else:
+			to_index = layer.index + 1
+	else: # Down
+		if layer.index == child_count: # If at the very bottom of the layer stack
+			if not is_instance_valid(layer.parent):
+				return
+			to_parents[-1] = layer.parent.parent # Drop a level in the hierarchy
+		else:
+			var below_layer: BaseLayer = project.layers[project.current_layer - 1 - child_count]
+			if layer.parent != below_layer.parent: # If there is a hierarchy change
+				to_parents[-1] = below_layer.parent
+			elif below_layer.accepts_child(layer):
+				to_parents[-1] = below_layer
+				to_index = layer.index - 1
+			else:
+				to_index = layer.index - 1
 
-	Global.current_project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
-	Global.current_project.undo_redo.add_do_method(Global, "undo_or_redo", false)
-	Global.current_project.undo_redo.commit_action()
+	var to_indices := range(to_index - child_count, to_index + 1)
+
+	project.undo_redo.create_action("Change Layer Order")
+	project.undo_redo.add_do_property(project, "current_layer", to_index)
+	project.undo_redo.add_do_method(project, "move_layers", from_indices, to_indices, to_parents)
+	project.undo_redo.add_undo_method(project, "move_layers", to_indices, from_indices, from_parents)
+	project.undo_redo.add_undo_property(project, "current_layer", project.current_layer)
+	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
+	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
+	project.undo_redo.commit_action()
 
 
 func _on_MergeDownLayer_pressed() -> void:
@@ -710,6 +729,9 @@ func _on_MergeDownLayer_pressed() -> void:
 
 	project.undos += 1
 	project.undo_redo.create_action("Merge Layer")
+
+	# TODO R0: When there is a group layer/cel present in the tree, merging down Pixel Layers
+	#			 doesn't get the texture updated. (Image is updated though, doing something else will update texture)
 
 	for f in project.frames:
 		# TODO Later: top_image here doesn't really need to be a copy if there isn't layer transparency

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -308,17 +308,12 @@ func copy_frames(frames := []) -> void:
 		copied_indices.append(frames[-1] + 1 + i)
 
 		var prev_frame: Frame = project.frames[frame]
-		for cel in prev_frame.cels:  # Copy every cel
-			# TODO: if Cel classes had a copy func, that would be quite useful here (and when copying layers)
-			var sprite := Image.new()
-			sprite.copy_from(cel.image)
-			var sprite_texture := ImageTexture.new()
-			sprite_texture.create_from_image(sprite, 0)
-			new_frame.cels.append(PixelCel.new(sprite, cel.opacity, sprite_texture))
+		for cel in prev_frame.cels:
+			new_frame.cels.append(cel.copy())
 
 		new_frame.duration = prev_frame.duration
 		for l_i in range(new_layers.size()):
-			if new_layers[l_i].new_cels_linked:  # If the link button is pressed
+			if new_layers[l_i].get("new_cels_linked"):  # If the link button is pressed
 				new_layers[l_i].linked_cels.append(new_frame)
 				new_frame.cels[l_i].image = new_layers[l_i].linked_cels[0].cels[l_i].image
 				new_frame.cels[l_i].image_texture = new_layers[l_i].linked_cels[0].cels[l_i].image_texture
@@ -592,7 +587,7 @@ func _on_FuturePlacement_item_selected(index: int) -> void:
 func add_layer(is_new := true) -> void:
 	# TODO: Duplicate functionality should probably be split out to allow for different layer types
 	# TODO: Bug where adding a layer isn't selecting the new layer?
-	Global.canvas.selection.transform_content_confirm()
+	Global.canvas.selection.transform_content_confirm() # TODO: Figure out once and for all, do these belong here, or in the project reversable functions (where these will be called on undo as well)
 	var l := PixelLayer.new()
 	var project: Project = Global.current_project
 	if !is_new:  # Clone layer

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -855,7 +855,8 @@ func project_frame_added(frame: int) -> void:
 
 
 func project_frame_removed(frame: int) -> void:
-	Global.frame_ids.get_child(frame).free()
+	Global.frame_ids.get_child(frame).queue_free()
+	Global.frame_ids.remove_child(Global.frame_ids.get_child(frame))
 	for container in Global.frames_container.get_children():
 		container.get_child(frame).free()
 
@@ -915,3 +916,8 @@ func project_cel_removed(frame: int, layer: int) -> void:
 		Global.frames_container.get_child_count() - 1 - layer
 	)
 	container.get_child(frame).free()
+
+# TODO: Consider if this is better kept here, inline in LayerButton, or as a method in LayerButton
+func update_layer_buttons() -> void:
+	for c in Global.layers_container.get_children():
+		c._ready() # TODO: Should there be a specific place for this?

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -799,6 +799,7 @@ func _on_OnionSkinningSettings_popup_hide() -> void:
 
 
 func project_changed() -> void:
+	# TODO H: Changing project takes twice as long as previously, why? (Not sure if this func is the problem)
 	var project: Project = Global.current_project # TODO R: maybe pass in instead?
 	# TODO R: Could using queue_free rather than free (or remove and queue_free) actually cause bugs?
 	for child in Global.layers_container.get_children():

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -275,7 +275,6 @@ func _on_CopyFrame_pressed(frame := -1) -> void:
 
 
 func copy_frames(frames := []) -> void:
-	Global.canvas.selection.transform_content_confirm()
 	var project: Project = Global.current_project
 
 	if frames.size() == 0:
@@ -522,8 +521,8 @@ func play_animation(play: bool, forward_dir: bool) -> void:
 
 
 func _on_NextFrame_pressed() -> void:
-	Global.canvas.selection.transform_content_confirm()
-	Global.current_project.selected_cels.clear()
+	Global.canvas.selection.transform_content_confirm() # TODO R4: These may be safe to remove, (frame_changed in project calls it)
+	Global.current_project.selected_cels.clear() # TODO NOTE: ^^ Though clearing the selected cels may mess that up.
 	if Global.current_project.current_frame < Global.current_project.frames.size() - 1:
 		Global.current_project.current_frame += 1
 
@@ -581,7 +580,6 @@ func _on_FuturePlacement_item_selected(index: int) -> void:
 
 
 func _on_AddLayer_pressed() -> void:
-	Global.canvas.selection.transform_content_confirm() # TODO R2: Figure out once and for all, do these belong here, or in the project reversable functions (where these will be called on undo as well)
 	var project: Project = Global.current_project
 
 	var l := PixelLayer.new()
@@ -603,7 +601,6 @@ func _on_AddLayer_pressed() -> void:
 
 
 func _on_AddGroup_pressed() -> void:
-	Global.canvas.selection.transform_content_confirm()
 	var project: Project = Global.current_project
 
 	var l := GroupLayer.new()
@@ -623,8 +620,6 @@ func _on_AddGroup_pressed() -> void:
 
 
 func _on_CloneLayer_pressed() -> void:
-	Global.canvas.selection.transform_content_confirm()
-
 	var project: Project = Global.current_project
 	var l: BaseLayer = project.layers[project.current_layer].copy()
 	l.name = str(project.layers[project.current_layer].name, " (", tr("copy"), ")")

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -13,7 +13,7 @@ var past_above_canvas := true
 var future_above_canvas := true
 
 var frame_button_node = preload("res://src/UI/Timeline/FrameButton.tscn")
-# TODO R: May remove some of these:
+# TODO R1: May remove some of these:
 var pixel_layer_button_node = preload("res://src/UI/Timeline/PixelLayerButton.tscn")
 var group_layer_button_node = preload("res://src/UI/Timeline/GroupLayerButton.tscn")
 
@@ -192,7 +192,7 @@ func _on_DeleteFrame_pressed(frame := -1) -> void:
 
 
 func delete_frames(frames := []) -> void:
-	# TODO R: If there is mulitple frames, it is currently possible to select and delete them all
+	# TODO R0: If there is mulitple frames, it is currently possible to select and delete them all
 	var project: Project = Global.current_project
 	if project.frames.size() == 1:
 		return
@@ -580,7 +580,7 @@ func _on_FuturePlacement_item_selected(index: int) -> void:
 
 
 func _on_AddLayer_pressed() -> void:
-	Global.canvas.selection.transform_content_confirm() # TODO R: Figure out once and for all, do these belong here, or in the project reversable functions (where these will be called on undo as well)
+	Global.canvas.selection.transform_content_confirm() # TODO R2: Figure out once and for all, do these belong here, or in the project reversable functions (where these will be called on undo as well)
 	var project: Project = Global.current_project
 
 	var l := PixelLayer.new()
@@ -632,7 +632,7 @@ func _on_CloneLayer_pressed() -> void:
 	for f in project.frames:
 		cels.append(f.cels[project.current_layer].copy())
 
-	# TODO R: Copies don't have linked cels properly set up...
+	# TODO R0: Copies don't have linked cels properly set up...
 
 	project.undos += 1
 	project.undo_redo.create_action("Add Layer")
@@ -646,7 +646,7 @@ func _on_CloneLayer_pressed() -> void:
 
 
 func _on_RemoveLayer_pressed() -> void:
-	# TODO R: It is currently possible to delete all layers (by having all layers in a group and deleting the group)
+	# TODO R0: It is currently possible to delete all layers (by having all layers in a group and deleting the group)
 	var project: Project = Global.current_project
 	if project.layers.size() == 1:
 		return
@@ -665,7 +665,7 @@ func _on_RemoveLayer_pressed() -> void:
 
 	project.undos += 1
 	project.undo_redo.create_action("Remove Layer")
-	# TODO R: what should be the new current layer?
+	# TODO R3: what should be the new current layer?
 	project.undo_redo.add_do_property(project, "current_layer", max(indices[0] - 1, 0))
 	project.undo_redo.add_undo_property(project, "current_layer", project.current_layer)
 	project.undo_redo.add_do_method(project, "remove_layers", indices)
@@ -706,7 +706,7 @@ func change_layer_order(rate: int) -> void:
 	Global.current_project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	Global.current_project.undo_redo.commit_action()
 
-# TODO R: Does this need to be part of the refactor?
+# TODO R0: Does this need to be part of the refactor?
 func _on_MergeDownLayer_pressed() -> void:
 	var new_layers: Array = Global.current_project.duplicate_layers()
 
@@ -800,8 +800,8 @@ func _on_OnionSkinningSettings_popup_hide() -> void:
 
 func project_changed() -> void:
 	# TODO H: Changing project takes twice as long as previously, why? (Not sure if this func is the problem)
-	var project: Project = Global.current_project # TODO R: maybe pass in instead?
-	# TODO R: Could using queue_free rather than free (or remove and queue_free) actually cause bugs?
+	var project: Project = Global.current_project # TODO R3: maybe pass in instead?
+	# TODO R2: Could using queue_free rather than free (or remove and queue_free) actually cause bugs?
 	for child in Global.layers_container.get_children():
 		child.queue_free()
 	for child in Global.frame_ids.get_children():
@@ -817,12 +817,12 @@ func project_changed() -> void:
 		Global.frame_ids.add_child(button)
 		Global.frame_ids.move_child(button, f)
 
-	# TODO R: Remove and inline what's needed here if this isn't used anywhere else:
+	# TODO R3: Remove and inline what's needed here if this isn't used anywhere else:
 	Global.current_project._update_animation_timeline_selection()
 
 
 func project_frame_added(frame: int) -> void:
-	var project: Project = Global.current_project # TODO R: maybe pass in instead?
+	var project: Project = Global.current_project # TODO R3: maybe pass in instead?
 	var button: Button = frame_button_node.instance()
 	button.frame = frame
 	Global.frame_ids.add_child(button)
@@ -847,16 +847,16 @@ func project_frame_removed(frame: int) -> void:
 
 func project_layer_added(layer: int) -> void:
 	var project: Project = Global.current_project
-	# TODO R: should probably have a "layer" variable... (to many project.layers[layer])...
+	# TODO R3: should probably have a "layer" variable... (to many project.layers[layer])...
 	#		...or refactor things so less of this code is needed here.
-	# TODO R: Could this function be organized in a better way?
+	# TODO R1: Could this function be organized in a better way?
 	var layer_button: LayerButton
 	if project.layers[layer] is PixelLayer:
 		layer_button = pixel_layer_button_node.instance()
 	elif project.layers[layer] is GroupLayer:
 		layer_button = group_layer_button_node.instance()
-	layer_button.layer = layer # TODO R: See if needed
-	if project.layers[layer].name == "": # TODO R: This probably could be somewhere else... add_layer(s) in project?
+	layer_button.layer = layer # TODO R1: See if needed
+	if project.layers[layer].name == "": # TODO R1: This probably could be somewhere else... add_layer(s) in project?
 		project.layers[layer].name = project.layers[layer].get_default_name(layer)
 
 	Global.layers_container.add_child(layer_button)
@@ -864,14 +864,14 @@ func project_layer_added(layer: int) -> void:
 	Global.layers_container.move_child(layer_button, count - 1 - layer)
 
 	var layer_cel_container := HBoxContainer.new()
-	# TODO R: Is there any need for a name (and why is it LAYERSSS in one place, and FRAMESS in another?)
+	# TODO R3: Is there any need for a name (and why is it LAYERSSS in one place, and FRAMESS in another?)
 	layer_cel_container.name = "LAYERSSS " + str(layer)
 	Global.frames_container.add_child(layer_cel_container)
 	Global.frames_container.move_child(layer_cel_container, count - 1 - layer)
 	for f in range(project.frames.size()):
 		var cel_button = project.frames[f].cels[layer].create_cel_button()
 		cel_button.frame = f
-		cel_button.layer = layer# - 1 # TODO R: See if needed
+		cel_button.layer = layer# - 1 # TODO R1: See if needed
 		layer_cel_container.add_child(cel_button)
 
 	layer_button.visible = Global.current_project.layers[layer].is_expanded_in_hierarchy()

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -810,9 +810,9 @@ func project_changed() -> void:
 	for container in Global.frames_container.get_children():
 		container.free()
 
-	for i in range(project.layers.size()):  # TODO R2: Could this be faster if it did it in reverse order?
+	for i in project.layers.size():
 		project_layer_added(i)
-	for f in range(project.frames.size()):
+	for f in project.frames.size():
 		var button: Button = frame_button_node.instance()
 		button.frame = f
 		Global.frame_ids.add_child(button)

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -664,7 +664,8 @@ func _on_RemoveLayer_pressed() -> void:
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 	project.undo_redo.commit_action()
 
-
+# Move the layer up or down in layer order and/or reparent to be deeper/shallower in the
+# layer hierarchy depending on its current index and parent
 func change_layer_order(up: bool) -> void:
 	var project: Project = Global.current_project
 	var layer: BaseLayer = project.layers[project.current_layer]
@@ -678,13 +679,15 @@ func change_layer_order(up: bool) -> void:
 
 	if up:
 		var above_layer: BaseLayer = project.layers[project.current_layer + 1]
-		if layer.parent == above_layer: # Above is the parent, leave the parent
+		if layer.parent == above_layer: # Above is the parent, leave the parent and go up
 			to_parents[-1] = above_layer.parent
 			to_index = layer.index + 1
 		elif layer.parent != above_layer.parent: # Above layer must be deeper in the hierarchy
-			to_parents[-1] = above_layer.parent # (this may be more than 1 level deeper)
+			# Move layer 1 level deeper in hierarchy. Done by setting its parent to the parent of
+			# above_layer, and if that is multiple levels, drop levels until its just 1
+			to_parents[-1] = above_layer.parent
 			while to_parents[-1].parent != layer.parent:
-				to_parents[-1]= to_parents[-1].parent # Incase we went multiple levels, drop extra
+				to_parents[-1] = to_parents[-1].parent
 		elif above_layer.accepts_child(layer):
 			to_parents[-1] = above_layer
 		else:

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -172,8 +172,8 @@ func add_frame() -> void:
 	project.undo_redo.create_action("Add Frame")
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
-	project.undo_redo.add_do_method(project, "add_frame", frame, frame_add_index)
-	project.undo_redo.add_undo_method(project, "remove_frame", frame_add_index)
+	project.undo_redo.add_do_method(project, "add_frames", [frame], [frame_add_index])
+	project.undo_redo.add_undo_method(project, "remove_frames", [frame_add_index])
 	project.undo_redo.add_do_property(project, "layers", new_layers)
 	project.undo_redo.add_undo_property(project, "layers", project.layers)
 	project.undo_redo.add_do_property(project, "animation_tags", new_animation_tags)
@@ -249,16 +249,14 @@ func delete_frames(frames := []) -> void:
 				tag.to -= 1
 		frame_correction += 1  # Compensation for the next batch
 
+	var frame_refs := []
+	for f in frames:
+		frame_refs.append(project.frames[f])
+
 	project.undos += 1
 	project.undo_redo.create_action("Remove Frame")
-	var x := frames.size() - 1
-	while x >= 0:
-		project.undo_redo.add_do_method(project, "remove_frame", frames[x])
-		x -= 1
-	for i in range(frames.size()):
-		project.undo_redo.add_undo_method(
-			project, "add_frame", project.frames[frames[i]], frames[i]
-		)
+	project.undo_redo.add_do_method(project, "remove_frames", frames)
+	project.undo_redo.add_undo_method(project, "add_frames", frame_refs, frames)
 	project.undo_redo.add_do_property(project, "layers", new_layers)
 	project.undo_redo.add_undo_property(project, "layers", Global.current_project.layers)
 	project.undo_redo.add_do_property(project, "animation_tags", new_animation_tags)

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -893,8 +893,8 @@ func project_layer_added(layer: int) -> void:
 #	maybe "layer_removed_in_project"? or something else?
 func project_layer_removed(layer: int) -> void:
 	var count := Global.layers_container.get_child_count()
-	Global.layers_container.get_child(count - layer).free()
-	Global.frames_container.get_child(count - layer).free()
+	Global.layers_container.get_child(count - 1 - layer).free()
+	Global.frames_container.get_child(count - 1 - layer).free()
 
 
 func project_cel_added(frame: int, layer: int) -> void:

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -306,7 +306,6 @@ func copy_frames(frames := []) -> void:
 			# If the layer has new_cels_linked variable, and its true
 			var new_cels_linked: bool = new_layers[l_i].get("new_cels_linked")
 
-			# TODO R3: Make sure this is working:
 			# Copy the cel, create new cel content if new cels aren't linked
 			new_frame.cels.append(new_layers[l_i].copy_cel(frame, new_cels_linked))
 

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -16,8 +16,6 @@ var frame_button_node = preload("res://src/UI/Timeline/FrameButton.tscn")
 # TODO R: May remove some of these:
 var pixel_layer_button_node = preload("res://src/UI/Timeline/PixelLayerButton.tscn")
 var group_layer_button_node = preload("res://src/UI/Timeline/GroupLayerButton.tscn")
-var pixel_cel_button_node = preload("res://src/UI/Timeline/PixelCelButton.tscn")
-var group_cel_button_node = preload("res://src/UI/Timeline/GroupCelButton.tscn")
 
 onready var old_scroll: int = 0  # The previous scroll state of $ScrollContainer
 onready var tag_spacer = find_node("TagSpacer")
@@ -194,6 +192,7 @@ func _on_DeleteFrame_pressed(frame := -1) -> void:
 
 
 func delete_frames(frames := []) -> void:
+	# TODO R: If there is mulitple frames, it is currently possible to select and delete them all
 	var project: Project = Global.current_project
 	if project.frames.size() == 1:
 		return
@@ -581,7 +580,6 @@ func _on_FuturePlacement_item_selected(index: int) -> void:
 
 
 func _on_AddLayer_pressed() -> void:
-	# TODO R: Duplicate functionality should probably be split out to allow for different layer types
 	Global.canvas.selection.transform_content_confirm() # TODO R: Figure out once and for all, do these belong here, or in the project reversable functions (where these will be called on undo as well)
 	var project: Project = Global.current_project
 
@@ -648,6 +646,7 @@ func _on_CloneLayer_pressed() -> void:
 
 
 func _on_RemoveLayer_pressed() -> void:
+	# TODO R: It is currently possible to delete all layers (by having all layers in a group and deleting the group)
 	var project: Project = Global.current_project
 	if project.layers.size() == 1:
 		return
@@ -891,8 +890,6 @@ func project_cel_added(frame: int, layer: int) -> void:
 	var cel_button = Global.current_project.frames[frame].cels[layer].create_cel_button()
 	cel_button.frame = frame
 	cel_button.layer = layer
-	# TODO R: Do we need stuff like this for selection?
-#	cel_button.pressed = Global.current_project.selected_cels.has([frame, layer])
 	container.add_child(cel_button)
 	container.move_child(cel_button, frame)
 

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -606,12 +606,12 @@ func add_layer(is_new := true) -> void:
 	project.undo_redo.create_action("Add Layer")
 	if is_new:
 		project.undo_redo.add_do_property(project, "current_layer", project.layers.size())
-		project.undo_redo.add_do_method(project, "add_layer", l, project.layers.size(), cels)
+		project.undo_redo.add_do_method(project, "add_layers", [l], [project.layers.size()], [cels])
 	else:
 		project.undo_redo.add_do_property(project, "current_layer", project.current_layer + 1)
-		project.undo_redo.add_do_method(project, "add_layer", l, project.current_layer + 1, cels)
+		project.undo_redo.add_do_method(project, "add_layers", [l], [project.current_layer + 1], [cels])
 	project.undo_redo.add_undo_property(project, "current_layer", project.current_layer)
-	project.undo_redo.add_undo_method(project, "remove_layer", project.layers.size())
+	project.undo_redo.add_undo_method(project, "remove_layers", [project.layers.size()])  # TODO R: this is the wrong index for a duplicated layer
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	project.undo_redo.commit_action()
@@ -630,8 +630,8 @@ func add_group_layer(is_new := true) -> void:
 	project.undo_redo.create_action("Add Layer")
 	project.undo_redo.add_do_property(project, "current_layer", project.layers.size())
 	project.undo_redo.add_undo_property(project, "current_layer", project.current_layer)
-	project.undo_redo.add_do_method(project, "add_layer", l, project.layers.size(), cels)
-	project.undo_redo.add_undo_method(project, "remove_layer", project.layers.size())
+	project.undo_redo.add_do_method(project, "add_layers", [l], [project.layers.size()], [cels])
+	project.undo_redo.add_undo_method(project, "remove_layers", [project.layers.size()])
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	project.undo_redo.commit_action()
@@ -651,9 +651,9 @@ func _on_RemoveLayer_pressed() -> void:
 
 	project.undo_redo.add_do_property(project, "current_layer", max(project.current_layer - 1, 0))
 	project.undo_redo.add_undo_property(project, "current_layer", project.current_layer)
-	project.undo_redo.add_do_method(project, "remove_layer", project.current_layer)
+	project.undo_redo.add_do_method(project, "remove_layers", [project.current_layer])
 	project.undo_redo.add_undo_method(
-		project, "add_layer", project.layers[project.current_layer], project.current_layer, cels
+		project, "add_layers", [project.layers[project.current_layer]], [project.current_layer], [cels]
 	)
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)

--- a/src/UI/Timeline/AnimationTimeline.tscn
+++ b/src/UI/Timeline/AnimationTimeline.tscn
@@ -173,6 +173,7 @@ margin_right = 53.0
 margin_bottom = 22.0
 rect_min_size = Vector2( 22, 22 )
 hint_tooltip = "Create a new group layer"
+focus_mode = 0
 mouse_default_cursor_shape = 2
 
 [node name="TextureRect" type="TextureRect" parent="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/AddGroup"]
@@ -1037,12 +1038,12 @@ color = Color( 0, 0.741176, 1, 0.501961 )
 
 [connection signal="item_rect_changed" from="." to="." method="_on_AnimationTimeline_item_rect_changed"]
 [connection signal="item_rect_changed" from="ScrollContainer/TimelineContainer" to="." method="_on_TimelineContainer_item_rect_changed"]
-[connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/AddLayer" to="." method="add_layer" binds= [ true ]]
-[connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/AddGroup" to="." method="add_group_layer" binds= [ true ]]
+[connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/AddLayer" to="." method="_on_AddLayer_pressed"]
+[connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/AddGroup" to="." method="_on_AddGroup_pressed"]
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/RemoveLayer" to="." method="_on_RemoveLayer_pressed"]
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/MoveUpLayer" to="." method="change_layer_order" binds= [ 1 ]]
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/MoveDownLayer" to="." method="change_layer_order" binds= [ -1 ]]
-[connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/CloneLayer" to="." method="add_layer" binds= [ false ]]
+[connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/CloneLayer" to="." method="_on_CloneLayer_pressed"]
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/MergeDownLayer" to="." method="_on_MergeDownLayer_pressed"]
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/PanelContainer/AnimationButtons/FrameButtons/AddFrame" to="." method="add_frame"]
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/PanelContainer/AnimationButtons/FrameButtons/DeleteFrame" to="." method="_on_DeleteFrame_pressed"]

--- a/src/UI/Timeline/AnimationTimeline.tscn
+++ b/src/UI/Timeline/AnimationTimeline.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=44 format=2]
+[gd_scene load_steps=43 format=2]
 
 [ext_resource path="res://src/UI/Timeline/AnimationTimeline.gd" type="Script" id=1]
 [ext_resource path="res://assets/graphics/layers/new.png" type="Texture" id=2]
@@ -8,7 +8,6 @@
 [ext_resource path="res://assets/graphics/layers/delete.png" type="Texture" id=6]
 [ext_resource path="res://assets/graphics/layers/clone.png" type="Texture" id=7]
 [ext_resource path="res://assets/graphics/timeline/move_arrow.png" type="Texture" id=8]
-[ext_resource path="res://src/UI/Timeline/FrameButton.tscn" type="PackedScene" id=9]
 [ext_resource path="res://assets/graphics/layers/group_new.png" type="Texture" id=10]
 [ext_resource path="res://assets/graphics/timeline/new_frame.png" type="Texture" id=19]
 [ext_resource path="res://assets/graphics/timeline/remove_frame.png" type="Texture" id=20]
@@ -876,7 +875,7 @@ margin_bottom = 68.0
 size_flags_horizontal = 3
 
 [node name="LayersAndFrames" type="HBoxContainer" parent="ScrollContainer/TimelineContainer/PanelContainer/HBoxContainer/TimelineScroll"]
-margin_right = 81.0
+margin_right = 45.0
 margin_bottom = 68.0
 size_flags_vertical = 3
 
@@ -899,22 +898,16 @@ margin_bottom = 20.0
 
 [node name="FrameButtonsAndIds" type="VBoxContainer" parent="ScrollContainer/TimelineContainer/PanelContainer/HBoxContainer/TimelineScroll/LayersAndFrames"]
 margin_left = 45.0
-margin_right = 81.0
+margin_right = 45.0
 margin_bottom = 68.0
 
 [node name="FrameIDs" type="HBoxContainer" parent="ScrollContainer/TimelineContainer/PanelContainer/HBoxContainer/TimelineScroll/LayersAndFrames/FrameButtonsAndIds"]
-margin_right = 36.0
-margin_bottom = 20.0
+margin_bottom = 16.0
 rect_min_size = Vector2( 0, 16 )
 
-[node name="FrameButton" parent="ScrollContainer/TimelineContainer/PanelContainer/HBoxContainer/TimelineScroll/LayersAndFrames/FrameButtonsAndIds/FrameIDs" instance=ExtResource( 9 )]
-margin_right = 36.0
-rect_min_size = Vector2( 36, 0 )
-
 [node name="FramesContainer" type="VBoxContainer" parent="ScrollContainer/TimelineContainer/PanelContainer/HBoxContainer/TimelineScroll/LayersAndFrames/FrameButtonsAndIds"]
-margin_top = 24.0
-margin_right = 36.0
-margin_bottom = 24.0
+margin_top = 20.0
+margin_bottom = 20.0
 
 [node name="EndSpacer" type="Control" parent="ScrollContainer/TimelineContainer/PanelContainer/HBoxContainer"]
 margin_left = 888.0

--- a/src/UI/Timeline/AnimationTimeline.tscn
+++ b/src/UI/Timeline/AnimationTimeline.tscn
@@ -219,7 +219,6 @@ __meta__ = {
 }
 
 [node name="MoveUpLayer" type="Button" parent="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons" groups=["UIButtons"]]
-visible = false
 margin_left = 93.0
 margin_right = 115.0
 margin_bottom = 22.0
@@ -246,9 +245,8 @@ __meta__ = {
 }
 
 [node name="MoveDownLayer" type="Button" parent="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons" groups=["UIButtons"]]
-visible = false
-margin_left = 93.0
-margin_right = 115.0
+margin_left = 124.0
+margin_right = 146.0
 margin_bottom = 22.0
 rect_min_size = Vector2( 22, 22 )
 hint_tooltip = "Move down the current layer"
@@ -273,8 +271,8 @@ __meta__ = {
 }
 
 [node name="CloneLayer" type="Button" parent="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons" groups=["UIButtons"]]
-margin_left = 93.0
-margin_right = 115.0
+margin_left = 155.0
+margin_right = 177.0
 margin_bottom = 22.0
 rect_min_size = Vector2( 22, 22 )
 hint_tooltip = "Clone current layer"
@@ -298,8 +296,8 @@ __meta__ = {
 }
 
 [node name="MergeDownLayer" type="Button" parent="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons" groups=["UIButtons"]]
-margin_left = 124.0
-margin_right = 146.0
+margin_left = 186.0
+margin_right = 208.0
 margin_bottom = 22.0
 rect_min_size = Vector2( 22, 22 )
 hint_tooltip = "Merge current layer with the one below"
@@ -1041,8 +1039,8 @@ color = Color( 0, 0.741176, 1, 0.501961 )
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/AddLayer" to="." method="_on_AddLayer_pressed"]
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/AddGroup" to="." method="_on_AddGroup_pressed"]
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/RemoveLayer" to="." method="_on_RemoveLayer_pressed"]
-[connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/MoveUpLayer" to="." method="change_layer_order" binds= [ 1 ]]
-[connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/MoveDownLayer" to="." method="change_layer_order" binds= [ -1 ]]
+[connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/MoveUpLayer" to="." method="change_layer_order" binds= [ true ]]
+[connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/MoveDownLayer" to="." method="change_layer_order" binds= [ false ]]
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/CloneLayer" to="." method="_on_CloneLayer_pressed"]
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/LayerButtonPanelContainer/LayerButtons/MergeDownLayer" to="." method="_on_MergeDownLayer_pressed"]
 [connection signal="pressed" from="ScrollContainer/TimelineContainer/TimelineButtons/PanelContainer/AnimationButtons/FrameButtons/AddFrame" to="." method="add_frame"]

--- a/src/UI/Timeline/BaseCelButton.tscn
+++ b/src/UI/Timeline/BaseCelButton.tscn
@@ -20,11 +20,13 @@ margin_top = 18.0
 margin_right = 36.0
 margin_bottom = 54.0
 rect_min_size = Vector2( 36, 36 )
+focus_mode = 0
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
 toggle_mode = true
 button_mask = 7
+enabled_focus_mode = 0
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/src/UI/Timeline/BaseLayerButton.tscn
+++ b/src/UI/Timeline/BaseLayerButton.tscn
@@ -8,10 +8,12 @@
 margin_right = 236.0
 margin_bottom = 36.0
 rect_min_size = Vector2( 236, 36 )
+focus_mode = 0
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 0
 toggle_mode = true
 action_mode = 0
+enabled_focus_mode = 0
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_horizontal_guides_": [  ],

--- a/src/UI/Timeline/FrameButton.gd
+++ b/src/UI/Timeline/FrameButton.gd
@@ -84,7 +84,7 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 			frame_properties.set_frame_label(frame)
 			frame_properties.set_frame_dur(Global.current_project.frames[frame].duration)
 
-# TODO: Remove this later... (or simplify?)
+
 func change_frame_order(rate: int) -> void:
 	var change = frame + rate
 	var project = Global.current_project

--- a/src/UI/Timeline/FrameButton.gd
+++ b/src/UI/Timeline/FrameButton.gd
@@ -88,17 +88,8 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 func change_frame_order(rate: int) -> void:
 	var change = frame + rate
 	var project = Global.current_project
-#	var new_frames: Array = Global.current_project.frames.duplicate()
-#	var temp = new_frames[frame]
-#	new_frames[frame] = new_frames[change]
-#	new_frames[change] = temp
 
 	project.undo_redo.create_action("Change Frame Order")
-#	project.undo_redo.add_do_property(project, "frames", new_frames)
-#	project.undo_redo.add_undo_property(
-#		project, "frames", project.frames
-#	)
-
 	project.undo_redo.add_do_method(project, "move_frame", frame, change)
 	project.undo_redo.add_undo_method(project, "move_frame", change, frame)
 
@@ -108,7 +99,6 @@ func change_frame_order(rate: int) -> void:
 		project.undo_redo.add_do_property(project, "current_frame", project.current_frame)
 
 	project.undo_redo.add_undo_property(project, "current_frame", project.current_frame)
-
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	project.undo_redo.commit_action()
@@ -149,37 +139,12 @@ func can_drop_data(_pos, data) -> bool:
 func drop_data(_pos, data) -> void:
 	var drop_frame = data[1]
 	var project = Global.current_project
-
-#	var drop_frames: Array = Global.current_project.frames.duplicate()
-#	var temp = drop_frames[frame]
-#	drop_frames[frame] = drop_frames[drop_frame]
-#	drop_frames[drop_frame] = temp
-
 	project.undo_redo.create_action("Change Frame Order")
-#	Global.current_project.undo_redo.add_do_property(Global.current_project, "frames", drop_frames)
-#	Global.current_project.undo_redo.add_undo_property(
-#		Global.current_project, "frames", Global.current_project.frames
-#	)
-#
-#	if Global.current_project.current_frame == drop_frame:
-#		Global.current_project.undo_redo.add_do_property(
-#			Global.current_project, "current_frame", frame
-#		)
-#	else:
-#		Global.current_project.undo_redo.add_do_property(
-#			Global.current_project, "current_frame", Global.current_project.current_frame
-#		)
-#
-#	Global.current_project.undo_redo.add_undo_property(
-#		Global.current_project, "current_frame", Global.current_project.current_frame
-#	)
-
 	if Input.is_action_pressed("ctrl"): # Swap frames
 		project.undo_redo.add_do_method(project, "swap_frame", frame, drop_frame)
 		project.undo_redo.add_undo_method(project, "swap_frame", frame, drop_frame)
 	else: # Move frames
 		var to_frame: int
-		# TODO: Test that this is correct: (after cel button ui changes)
 		if _get_region_rect(0, 0.5).has_point(get_global_mouse_position()): # Left
 			to_frame = frame
 		else: # Right

--- a/src/UI/Timeline/FrameButton.gd
+++ b/src/UI/Timeline/FrameButton.gd
@@ -180,10 +180,12 @@ func drop_data(_pos, data) -> void:
 	else: # Move frames
 		var to_frame: int
 		# TODO: Test that this is correct: (after cel button ui changes)
-		if _get_region_rect(0, 0.5).has_point(get_global_mouse_position()):
+		if _get_region_rect(0, 0.5).has_point(get_global_mouse_position()): # Left
 			to_frame = frame
-		else:
+		else: # Right
 			to_frame = frame + 1
+		if drop_frame < frame:
+			to_frame -= 1
 		project.undo_redo.add_do_method(project, "move_frame", drop_frame, to_frame)
 		project.undo_redo.add_undo_method(project, "move_frame", to_frame, drop_frame)
 

--- a/src/UI/Timeline/FrameButton.gd
+++ b/src/UI/Timeline/FrameButton.gd
@@ -7,6 +7,8 @@ onready var frame_properties: ConfirmationDialog = Global.control.find_node("Fra
 
 
 func _ready() -> void:
+	rect_min_size.x = Global.animation_timeline.cel_size
+	text = str(frame + 1)
 	connect("pressed", self, "_button_pressed")
 	connect("mouse_entered", self, "_update_tooltip")
 

--- a/src/UI/Timeline/FrameButton.gd
+++ b/src/UI/Timeline/FrameButton.gd
@@ -82,36 +82,34 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 			frame_properties.set_frame_label(frame)
 			frame_properties.set_frame_dur(Global.current_project.frames[frame].duration)
 
-
+# TODO: Remove this later... (or simplify?)
 func change_frame_order(rate: int) -> void:
 	var change = frame + rate
-	var new_frames: Array = Global.current_project.frames.duplicate()
-	var temp = new_frames[frame]
-	new_frames[frame] = new_frames[change]
-	new_frames[change] = temp
+	var project = Global.current_project
+#	var new_frames: Array = Global.current_project.frames.duplicate()
+#	var temp = new_frames[frame]
+#	new_frames[frame] = new_frames[change]
+#	new_frames[change] = temp
 
-	Global.current_project.undo_redo.create_action("Change Frame Order")
-	Global.current_project.undo_redo.add_do_property(Global.current_project, "frames", new_frames)
-	Global.current_project.undo_redo.add_undo_property(
-		Global.current_project, "frames", Global.current_project.frames
-	)
+	project.undo_redo.create_action("Change Frame Order")
+#	project.undo_redo.add_do_property(project, "frames", new_frames)
+#	project.undo_redo.add_undo_property(
+#		project, "frames", project.frames
+#	)
 
-	if Global.current_project.current_frame == frame:
-		Global.current_project.undo_redo.add_do_property(
-			Global.current_project, "current_frame", change
-		)
+	project.undo_redo.add_do_method(project, "move_frame", frame, change)
+	project.undo_redo.add_undo_method(project, "move_frame", change, frame)
+
+	if project.current_frame == frame:
+		project.undo_redo.add_do_property(project, "current_frame", change)
 	else:
-		Global.current_project.undo_redo.add_do_property(
-			Global.current_project, "current_frame", Global.current_project.current_frame
-		)
+		project.undo_redo.add_do_property(project, "current_frame", project.current_frame)
 
-	Global.current_project.undo_redo.add_undo_property(
-		Global.current_project, "current_frame", Global.current_project.current_frame
-	)
+	project.undo_redo.add_undo_property(project, "current_frame", project.current_frame)
 
-	Global.current_project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
-	Global.current_project.undo_redo.add_do_method(Global, "undo_or_redo", false)
-	Global.current_project.undo_redo.commit_action()
+	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
+	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
+	project.undo_redo.commit_action()
 
 
 func get_drag_data(_position) -> Array:

--- a/src/UI/Timeline/FrameButton.tscn
+++ b/src/UI/Timeline/FrameButton.tscn
@@ -5,9 +5,11 @@
 [node name="FrameButton" type="Button"]
 margin_right = 12.0
 margin_bottom = 20.0
+focus_mode = 0
 mouse_default_cursor_shape = 2
 toggle_mode = true
 button_mask = 7
+enabled_focus_mode = 0
 text = "1"
 script = ExtResource( 1 )
 __meta__ = {

--- a/src/UI/Timeline/GroupCelButton.gd
+++ b/src/UI/Timeline/GroupCelButton.gd
@@ -31,7 +31,7 @@ func _on_GroupCelButton_resized() -> void:
 
 
 func _pressed():
-	# TODO: PixelCelButton could just use the func instead of signal too
+	# TODO L: PixelCelButton could just use the func instead of signal too
 
-	# TODO: Some of the funtionality from PixelCelButton needs to be moved over
+	# TODO H: Some of the funtionality from PixelCelButton needs to be moved over
 	pass

--- a/src/UI/Timeline/GroupCelButton.gd
+++ b/src/UI/Timeline/GroupCelButton.gd
@@ -5,8 +5,6 @@ var layer := 0
 var cel: GroupCel
 var mat: Material
 
-onready var popup_menu: PopupMenu = $PopupMenu
-
 
 func _ready() -> void:
 	button_setup()

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -74,7 +74,7 @@ func _update_buttons() -> void:
 
 
 func _update_buttons_all_layers() -> void:
-	# TODO R: would it be better to have specified range? (if so rename all_layers to for_layers)
+	# TODO R2: would it be better to have specified range? (if so rename all_layers to for_layers)
 	#			Maybe update_buttons_recursive (including children) is all we need?
 	for layer_button in Global.layers_container.get_children():
 		layer_button._update_buttons()
@@ -262,9 +262,9 @@ func drop_data(_pos, data) -> void:
 	project.undo_redo.create_action("Change Layer Order")
 	var new_layers: Array = project.layers.duplicate()
 
-	# TODO R: Check for other loops that could be replaced with a range...
-	# TODO R: new_layers is a little confusing, does it acutally need to be duplicated anymore? It shouldn't be modified...
-	# TODO R: can this code be made easier to read?
+	# TODO R1: Check for other loops that could be replaced with a range...
+	# TODO R1: new_layers is a little confusing, does it acutally need to be duplicated anymore? It shouldn't be modified...
+	# TODO R1: can this code be made easier to read?
 
 	var drop_from_indices := range(drop_layer - new_layers[drop_layer].get_children_recursive().size(), drop_layer + 1 )
 
@@ -291,7 +291,7 @@ func drop_data(_pos, data) -> void:
 
 		a["to_parents"] = a_from_parents.duplicate()
 		b["to_parents"] = drop_from_parents.duplicate()
-		for i in a.to_parents.size(): # TODO R: comment to explain this
+		for i in a.to_parents.size(): # TODO R0: comment to explain this
 			if a.to_parents[i] == a_from_parents[-1]:
 				a.to_parents[i] = drop_from_parents[-1]
 		for i in b.to_parents.size():

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -74,7 +74,7 @@ func _update_buttons() -> void:
 
 
 func _update_buttons_all_layers() -> void:
-	# TODO R2: would it be better to have specified range? (if so rename all_layers to for_layers)
+	# TODO R3: would it be better to have specified range? (if so rename all_layers to for_layers)
 	#			Maybe update_buttons_recursive (including children) is all we need?
 	for layer_button in Global.layers_container.get_children():
 		layer_button._update_buttons()
@@ -263,7 +263,6 @@ func drop_data(_pos, data) -> void:
 	project.undo_redo.create_action("Change Layer Order")
 	var new_layers: Array = project.layers.duplicate()
 
-	# TODO R1: Check for other loops that could be replaced with a range...
 	# TODO R1: new_layers is a little confusing, does it acutally need to be duplicated anymore? It shouldn't be modified...
 	# TODO R1: can this code be made easier to read?
 

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -74,7 +74,7 @@ func _update_buttons() -> void:
 
 
 func _update_buttons_all_layers() -> void:
-	# TODO R3: would it be better to have specified range? (if so rename all_layers to for_layers)
+	# TODO R4: would it be better to have specified range? (if so rename all_layers to for_layers)
 	#			Maybe update_buttons_recursive (including children) is all we need?
 	for layer_button in Global.layers_container.get_children():
 		layer_button._update_buttons()

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -193,17 +193,18 @@ func _select_current_layer() -> void:
 
 
 func get_drag_data(_position) -> Array:
+	# TODO H: If keeping this new multi layer drag design, layers here can be reutrned in the array
+	#			instead of layer...
 	var layers := range(layer - Global.current_project.layers[layer].get_children_recursive().size(), layer + 1)
 
 	var box := VBoxContainer.new()
-
-	for i in range(layers.size()):
+	for i in layers.size():
 		var button := Button.new()
 		button.rect_min_size = rect_size
 		button.theme = Global.control.theme
 		button.text = Global.current_project.layers[layers[-1 - i]].name
 		box.add_child(button)
-		set_drag_preview(box)
+	set_drag_preview(box)
 
 	return ["Layer", layer]
 
@@ -289,14 +290,13 @@ func drop_data(_pos, data) -> void:
 		for l in a.from:
 			a_from_parents.append(new_layers[l].parent)
 
+		# to_parents starts as a dulpicate of from_parents, set the root layer's (with one layer or
+		# group with its children, this will always be the last layer [-1]) parent to the other
+		# root layer's parent
 		a["to_parents"] = a_from_parents.duplicate()
 		b["to_parents"] = drop_from_parents.duplicate()
-		for i in a.to_parents.size(): # TODO R0: comment to explain this
-			if a.to_parents[i] == a_from_parents[-1]:
-				a.to_parents[i] = drop_from_parents[-1]
-		for i in b.to_parents.size():
-			if b.to_parents[i] == drop_from_parents[-1]:
-				b.to_parents[i] = a_from_parents[-1]
+		a.to_parents[-1] = drop_from_parents[-1]
+		b.to_parents[-1] = a_from_parents[-1]
 
 		project.undo_redo.add_do_method(project, "swap_layers", a, b)
 		project.undo_redo.add_undo_method(project, "swap_layers",

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -56,13 +56,12 @@ func _ready() -> void:
 	hierarchy_spacer.rect_min_size.x = hierarchy_depth * HIERARCHY_DEPTH_PIXEL_SHIFT
 
 	if Global.control.theme.get_color("font_color", "Button").v > 0.5: # Light text is dark theme
-		self_modulate.v += hierarchy_depth * 0.4
+		self_modulate.v = 1 + hierarchy_depth * 0.4
 	else: # Dark text should be light theme
-		self_modulate.v -= hierarchy_depth * 0.075
+		self_modulate.v = 1 - hierarchy_depth * 0.075
 
 	if is_instance_valid(Global.current_project.layers[layer].parent):
-		if not Global.current_project.layers[layer].parent.is_expanded_in_hierarchy():
-			visible = false
+		visible = Global.current_project.layers[layer].parent.is_expanded_in_hierarchy()
 		if not Global.current_project.layers[layer].parent.is_visible_in_hierarchy():
 			visibility_button.modulate.a = 0.33
 		if Global.current_project.layers[layer].parent.is_locked_in_hierarchy():
@@ -133,6 +132,7 @@ func _save_layer_name(new_name: String) -> void:
 
 func _on_ExpandButton_pressed():
 	Global.current_project.layers[layer].expanded = !Global.current_project.layers[layer].expanded
+	Global.animation_timeline.update_layer_buttons()
 
 
 func _on_VisibilityButton_pressed() -> void:
@@ -140,12 +140,14 @@ func _on_VisibilityButton_pressed() -> void:
 	Global.current_project.layers[layer].visible = !Global.current_project.layers[layer].visible
 	Global.canvas.update()
 	_select_current_layer()
+	Global.animation_timeline.update_layer_buttons()
 
 
 func _on_LockButton_pressed() -> void:
 	Global.canvas.selection.transform_content_confirm()
 	Global.current_project.layers[layer].locked = !Global.current_project.layers[layer].locked
 	_select_current_layer()
+	Global.animation_timeline.update_layer_buttons()
 
 
 func _on_LinkButton_pressed() -> void:
@@ -161,6 +163,7 @@ func _on_LinkButton_pressed() -> void:
 		container.get_child(Global.current_project.current_frame).button_setup()
 
 	Global.current_project.layers = Global.current_project.layers  # Call the setter
+	Global.animation_timeline.update_layer_buttons() # TODO: this one doesn't need to update all (and others only a specific range)
 
 
 func _select_current_layer() -> void:

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -74,7 +74,7 @@ func _update_buttons() -> void:
 
 
 func _update_buttons_all_layers() -> void:
-	# TODO R4: would it be better to have specified range? (if so rename all_layers to for_layers)
+	# TODO R3: would it be better to have specified range? (if so rename all_layers to for_layers)
 	#			Maybe update_buttons_recursive (including children) is all we need?
 	for layer_button in Global.layers_container.get_children():
 		layer_button._update_buttons()
@@ -262,8 +262,6 @@ func drop_data(_pos, data) -> void:
 
 	project.undo_redo.create_action("Change Layer Order")
 	var layers: Array = project.layers # This shouldn't be modified directly
-
-	# TODO R1: can this code be made easier to read?
 
 	var drop_from_indices := range(drop_layer - layers[drop_layer].get_children_recursive().size(), drop_layer + 1 )
 

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -72,10 +72,8 @@ func _update_buttons() -> void:
 		if Global.current_project.layers[layer].parent.is_locked_in_hierarchy():
 			lock_button.modulate.a = 0.33
 
-
+# Used when pressing a button on this changes the appearnce of other layers (ie: expand or visible)
 func _update_buttons_all_layers() -> void:
-	# TODO R3: would it be better to have specified range? (if so rename all_layers to for_layers)
-	#			Maybe update_buttons_recursive (including children) is all we need?
 	for layer_button in Global.layers_container.get_children():
 		layer_button._update_buttons()
 		var expanded = Global.current_project.layers[layer_button.layer].is_expanded_in_hierarchy()

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -38,7 +38,7 @@ func _ready() -> void:
 	_update_buttons()
 
 
-func _update_buttons():
+func _update_buttons() -> void:
 	if hide_expand_button:
 		expand_button.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		expand_button.get_child(0).visible = false  # Hide the TextureRect
@@ -75,8 +75,6 @@ func _update_buttons():
 
 func _update_buttons_all_layers() -> void:
 	# TODO: would it be better to have specified range? (if so rename all_layers to for_layers)
-	# TODO: IDK if this the right place to put it, but sometimes when moving a layer into a group
-	#		their heirachy visualization isn't at the right level (perhaps not removed and readded?)
 	for layer_button in Global.layers_container.get_children():
 		layer_button._update_buttons()
 		var expanded = Global.current_project.layers[layer_button.layer].is_expanded_in_hierarchy()
@@ -84,7 +82,7 @@ func _update_buttons_all_layers() -> void:
 		Global.frames_container.get_child(layer_button.get_index()).visible = expanded
 
 
-func _draw():
+func _draw() -> void:
 	if hierarchy_spacer.rect_size.x > 0.1:
 		var color := Color(1, 1, 1, 0.33)
 		color.v = round(Global.control.theme.get_color("font_color", "Button").v)

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -321,9 +321,11 @@ func drop_data(_pos, data) -> void:
 		project.undo_redo.add_undo_method(
 			project, "move_layers", to_indices, from_indices, from_parents
 		)
-	if project.current_layer == layer:
-		project.undo_redo.add_do_property(project, "current_layer", drop_layer)
-		project.undo_redo.add_undo_property(project, "current_layer", project.current_layer)
+	if project.current_layer == drop_layer: # TODO: This doesn't work...
+		project.undo_redo.add_do_property(project, "current_layer", layer)
+	else:
+		project.undo_redo.add_do_property(project, "current_layer", project.current_layer)
+	project.undo_redo.add_undo_property(project, "current_layer", project.current_layer)
 	# TODO: undo_or_redo is at end here, but earlier in others, does it matter which order?
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -139,7 +139,6 @@ func _save_layer_name(new_name: String) -> void:
 	line_edit.visible = false
 	line_edit.editable = false
 	label.text = new_name
-	Global.layers_changed_skip = true
 	Global.current_project.layers[layer].name = new_name
 
 
@@ -177,7 +176,6 @@ func _on_LinkButton_pressed() -> void:
 		var container = Global.frames_container.get_child(Global.current_project.current_layer)
 		container.get_child(Global.current_project.current_frame).button_setup()
 
-	Global.current_project.layers = Global.current_project.layers  # Call the setter
 	_update_buttons()
 
 

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -322,7 +322,7 @@ func drop_data(_pos, data) -> void:
 		project.undo_redo.add_undo_method(
 			project, "move_layers", to_indices, from_indices, from_parents
 		)
-	if project.current_layer == drop_layer: # TODO R: This doesn't work... (Actually I think this was fixed?, should match FrameButton)
+	if project.current_layer == drop_layer:
 		project.undo_redo.add_do_property(project, "current_layer", layer)
 	else:
 		project.undo_redo.add_do_property(project, "current_layer", project.current_layer)

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -303,9 +303,7 @@ func drop_data(_pos, data) -> void:
 		)
 
 	else: # Move layers
-		# TODO R1: would it make it more consistent (and easier to read) if to_index was changed
-		#			to use the highest layer?
-		var to_index: int # the index where the LOWEST shifted layer should end up
+		var to_index: int # the index where the LOWEST moved layer should end up
 		var to_parent: BaseLayer
 
 		# If accepted as a child, is it in the center region?

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -74,7 +74,8 @@ func _update_buttons() -> void:
 
 
 func _update_buttons_all_layers() -> void:
-	# TODO: would it be better to have specified range? (if so rename all_layers to for_layers)
+	# TODO R: would it be better to have specified range? (if so rename all_layers to for_layers)
+	#			Maybe update_buttons_recursive (including children) is all we need?
 	for layer_button in Global.layers_container.get_children():
 		layer_button._update_buttons()
 		var expanded = Global.current_project.layers[layer_button.layer].is_expanded_in_hierarchy()
@@ -145,7 +146,7 @@ func _save_layer_name(new_name: String) -> void:
 
 
 func _on_ExpandButton_pressed():
-	# TODO: What should happen when the current_layer or selected_cels are children of a layer you collapse?
+	# TODO L: What should happen when the current_layer or selected_cels are children of a layer you collapse?
 	#		Should the current_layer/selection move to ones aren't collapsed? Maybe add to github list of possible later changes
 	Global.current_project.layers[layer].expanded = !Global.current_project.layers[layer].expanded
 	_update_buttons_all_layers()
@@ -250,17 +251,17 @@ func can_drop_data(_pos, data) -> bool:
 
 func drop_data(_pos, data) -> void:
 	var drop_layer: int = data[1]
-	var project = Global.current_project # TODO: perhaps having a project variable for the enitre class would be nice (also for cel/frame buttons)
+	var project = Global.current_project # TODO L: perhaps having a project variable for the enitre class would be nice (also for cel/frame buttons)
 
 	project.undo_redo.create_action("Change Layer Order")
 	var new_layers: Array = project.layers.duplicate()
 	var temp: BaseLayer = new_layers[layer]
-	if Input.is_action_pressed("ctrl"): # Swap layers # TODO Need to check when swapping is allowed
-		pass # TODO: Figure out swapping
+	if Input.is_action_pressed("ctrl"): # Swap layers
+		pass # TODO R: Figure out swapping
 #		new_layers[layer] = new_layers[drop_layer]
 #		new_layers[drop_layer] = temp
 #
-#		# TODO: Make sure to swap parents too
+#		# TODO R: Make sure to swap parents too
 #
 #		for f in Global.current_project.frames:
 #			var new_cels: Array = f.cels.duplicate()
@@ -269,10 +270,10 @@ func drop_data(_pos, data) -> void:
 #			new_cels[drop_layer] = temp_canvas
 #			project.undo_redo.add_do_property(f, "cels", new_cels)
 #			project.undo_redo.add_undo_property(f, "cels", f.cels)
-	# TODO: Having "SourceLayers/OldLayers (that you don't change) and new_layers would make this less confusing
+	# TODO R: Having "SourceLayers/OldLayers (that you don't change) and new_layers would make this less confusing
 	else:
 		# from_indices should be in order of the layer indices, starting from the lowest
-		# TODO: can this code be made easier to read?
+		# TODO R: can this code be made easier to read?
 		var from_indices := []
 		for c in new_layers[drop_layer].get_children_recursive():
 			from_indices.append(c.index)
@@ -290,7 +291,7 @@ func drop_data(_pos, data) -> void:
 		else:
 			# Top or bottom region?
 			if _get_region_rect(0, 0.5).has_point(get_global_mouse_position()):
-				to_index = layer + 1 # TODO Is this right?
+				to_index = layer + 1
 				to_parent = new_layers[layer].parent
 			else:
 				# Place under the layer, if it has children, place after its lowest child
@@ -300,7 +301,7 @@ func drop_data(_pos, data) -> void:
 					if new_layers[layer].is_a_parent_of(new_layers[drop_layer]):
 						to_index += from_indices.size()
 				else:
-					to_index = layer # TODO Is this right?
+					to_index = layer
 				to_parent = new_layers[layer].parent
 
 		if drop_layer < layer:
@@ -321,12 +322,11 @@ func drop_data(_pos, data) -> void:
 		project.undo_redo.add_undo_method(
 			project, "move_layers", to_indices, from_indices, from_parents
 		)
-	if project.current_layer == drop_layer: # TODO: This doesn't work...
+	if project.current_layer == drop_layer: # TODO R: This doesn't work... (Actually I think this was fixed?, should match FrameButton)
 		project.undo_redo.add_do_property(project, "current_layer", layer)
 	else:
 		project.undo_redo.add_do_property(project, "current_layer", project.current_layer)
 	project.undo_redo.add_undo_property(project, "current_layer", project.current_layer)
-	# TODO: undo_or_redo is at end here, but earlier in others, does it matter which order?
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	project.undo_redo.commit_action()

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -233,48 +233,7 @@ func drop_data(_pos, data) -> void:
 	var drop_layer = data[2]
 	var project = Global.current_project
 
-#	var this_frame_new_cels = project.frames[frame].cels.duplicate()
-#	var drop_frame_new_cels
-#	var temp = this_frame_new_cels[layer]
-#	this_frame_new_cels[layer] = project.frames[drop_frame].cels[drop_layer]
-#	if frame == drop_frame:
-#		this_frame_new_cels[drop_layer] = temp
-#	else:
-#		drop_frame_new_cels = project.frames[drop_frame].cels.duplicate()
-#		drop_frame_new_cels[drop_layer] = temp
-
 	project.undo_redo.create_action("Move Cels")
-#	project.undo_redo.add_do_property(
-#		project.frames[frame], "cels", this_frame_new_cels
-#	)
-#
-#	project.undo_redo.add_do_property(project, "current_layer", layer)
-#	project.undo_redo.add_undo_property(
-#		project, "current_layer", project.current_layer
-#	)
-#
-#	if frame != drop_frame:  # If the cel moved to a different frame
-#		project.undo_redo.add_do_property(
-#			project.frames[drop_frame], "cels", drop_frame_new_cels
-#		)
-#
-#		project.undo_redo.add_do_property(
-#			project, "current_frame", frame
-#		)
-#		project.undo_redo.add_undo_property(
-#			project, "current_frame", project.current_frame
-#		)
-#
-#		project.undo_redo.add_undo_property(
-#			project.frames[drop_frame],
-#			"cels",
-#			project.frames[drop_frame].cels
-#		)
-#
-#	project.undo_redo.add_undo_property(
-#		project.frames[frame], "cels", project.frames[frame].cels
-#	)
-
 	if Input.is_action_pressed("ctrl") or layer != drop_layer: # Swap cels
 		project.undo_redo.add_do_method(project, "swap_cel", frame, layer, drop_frame, drop_layer)
 		project.undo_redo.add_undo_method(project, "swap_cel", frame, layer, drop_frame, drop_layer)

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -107,7 +107,7 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 
 		MenuOptions.LINK:
 			# TODO R3: If you do part of linked cels in add/remove frames, consider changes here:
-			# TODO R3: Make add_do/undo_property/method order consistent
+			# TODO R4: Make add_do/undo_property/method order consistent (and make sure it doesn't cause issues)
 			var project: Project = Global.current_project
 			var f: Frame = project.frames[frame]
 			var cel_index: int = project.layers[layer].linked_cels.find(f)

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -9,7 +9,7 @@ var image: Image
 
 onready var popup_menu: PopupMenu = $PopupMenu
 
-
+# TODO: The linked indicator seems to not get updated properly (adding a new linked cel won't show the indicator until another timeline change, same with linking an existing cel)
 func _ready() -> void:
 	button_setup()
 

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -114,7 +114,7 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 				new_cels[i] = PixelCel.new(
 					new_cels[i].image, new_cels[i].opacity, new_cels[i].image_texture
 				)
-# TODO R3: Make sure all this stuff still works after refactor:
+			# TODO H: Make sure all this works with group layers:
 			if popup_menu.get_item_metadata(MenuOptions.LINK) == "Unlink Cel":
 				new_layers[layer].linked_cels.remove(cel_index)
 				var sprite := Image.new()

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -127,24 +127,13 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 				sprite_texture.create_from_image(sprite, 0)
 				new_cels[layer].image = sprite
 				new_cels[layer].image_texture = sprite_texture
-
 				project.undo_redo.create_action("Unlink Cel")
-				project.undo_redo.add_do_property(project, "layers", new_layers)
-				project.undo_redo.add_do_method(self, "button_setup")
 				project.undo_redo.add_do_property(f, "cels", new_cels)
-				project.undo_redo.add_undo_property(project, "layers", project.layers)
-				project.undo_redo.add_undo_method(self, "button_setup")
 				project.undo_redo.add_undo_property(f, "cels", f.cels)
-
-				project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
-				project.undo_redo.add_do_method(Global, "undo_or_redo", false)
-				project.undo_redo.commit_action()
 
 			elif popup_menu.get_item_metadata(MenuOptions.LINK) == "Link Cel":
 				new_layers[layer].linked_cels.append(f)
 				project.undo_redo.create_action("Link Cel")
-				project.undo_redo.add_do_property(project, "layers", new_layers)
-				project.undo_redo.add_do_method(self, "button_setup")
 				if new_layers[layer].linked_cels.size() > 1:
 					# If there are already linked cels, set the current cel's image
 					# to the first linked cel's image
@@ -153,11 +142,17 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 					project.undo_redo.add_do_property(f, "cels", new_cels)
 					project.undo_redo.add_undo_property(f, "cels", f.cels)
 
-				project.undo_redo.add_undo_property(project, "layers", project.layers)
-				project.undo_redo.add_undo_method(self, "button_setup")
-				project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
-				project.undo_redo.add_do_method(Global, "undo_or_redo", false)
-				project.undo_redo.commit_action()
+			project.undo_redo.add_do_property(project, "layers", new_layers)
+			project.undo_redo.add_undo_property(project, "layers", project.layers)
+			# Remove and add a new cel button to update appearance
+			project.undo_redo.add_do_method(Global.animation_timeline, "project_cel_removed", frame, layer)
+			project.undo_redo.add_undo_method(Global.animation_timeline, "project_cel_removed", frame, layer)
+			project.undo_redo.add_do_method(Global.animation_timeline, "project_cel_added", frame, layer)
+			project.undo_redo.add_undo_method(Global.animation_timeline, "project_cel_added", frame, layer)
+
+			project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
+			project.undo_redo.add_do_method(Global, "undo_or_redo", false)
+			project.undo_redo.commit_action()
 
 
 func _delete_cel_content() -> void:

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -109,7 +109,7 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 			var new_layers: Array = Global.current_project.duplicate_layers()
 			var new_cels: Array = f.cels.duplicate()
 			for i in new_cels.size():
-				# TODO: This doesn't work
+				# TODO: This doesn't work (currently replaces ALL cels on the frame)
 				new_cels[i] = PixelCel.new(
 					new_cels[i].image, new_cels[i].opacity, new_cels[i].image_texture
 				)

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -143,7 +143,8 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 
 			project.undo_redo.add_do_property(project, "layers", new_layers)
 			project.undo_redo.add_undo_property(project, "layers", project.layers)
-			# Remove and add a new cel button to update appearance
+			# Remove and add a new cel button to update appearance (can't use self.button_setup
+			# because there is no guarantee that it will be the exact same cel button instance)
 			project.undo_redo.add_do_method(Global.animation_timeline, "project_cel_removed", frame, layer)
 			project.undo_redo.add_undo_method(Global.animation_timeline, "project_cel_removed", frame, layer)
 			project.undo_redo.add_do_method(Global.animation_timeline, "project_cel_added", frame, layer)

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -280,9 +280,6 @@ func drop_data(_pos, data) -> void:
 		project.undo_redo.add_undo_method(project, "swap_cel", frame, layer, drop_frame, drop_layer)
 	else: # Move cels
 		var to_frame: int
-		# TODO: Test that this is correct: (after cel button ui changes)
-		# TODO: This breaks sometimes (after several tests usually), I'm not sure what the condition it breaks in is, maybe need to draw it out?
-		#		(This is probably an error in the project.move_cel function)
 		if _get_region_rect(0, 0.5).has_point(get_global_mouse_position()): # Left
 			to_frame = frame
 		else: # Right

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -9,7 +9,7 @@ var image: Image
 
 onready var popup_menu: PopupMenu = $PopupMenu
 
-# TODO R: The linked indicator seems to not get updated properly (adding a new linked cel won't show the indicator until another timeline change, same with linking an existing cel)
+# TODO R0: The linked indicator seems to not get updated properly (adding a new linked cel won't show the indicator until another timeline change, same with linking an existing cel)
 func _ready() -> void:
 	button_setup()
 
@@ -103,7 +103,7 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 			_delete_cel_content()
 
 		MenuOptions.LINK:
-			# TODO R: See if there is any refactoring to do here:
+			# TODO R0: See if there is any refactoring to do here:
 			var f: Frame = Global.current_project.frames[frame]
 			var cel_index: int = Global.current_project.layers[layer].linked_cels.find(f)
 			var new_layers: Array = Global.current_project.duplicate_layers()
@@ -113,7 +113,7 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 				new_cels[i] = PixelCel.new(
 					new_cels[i].image, new_cels[i].opacity, new_cels[i].image_texture
 				)
-# TODO R: Make sure all this stuff still works after refactor:
+# TODO R3: Make sure all this stuff still works after refactor:
 			if popup_menu.get_item_metadata(MenuOptions.LINK) == "Unlink Cel":
 				new_layers[layer].linked_cels.remove(cel_index)
 				var sprite := Image.new()

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -103,7 +103,6 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 			_delete_cel_content()
 
 		MenuOptions.LINK:
-			# TODO R3: If you do part of linked cels in add/remove frames, consider changes here:
 			var project: Project = Global.current_project
 			var f: Frame = project.frames[frame]
 			var cel_index: int = project.layers[layer].linked_cels.find(f)

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -9,7 +9,7 @@ var image: Image
 
 onready var popup_menu: PopupMenu = $PopupMenu
 
-# TODO: The linked indicator seems to not get updated properly (adding a new linked cel won't show the indicator until another timeline change, same with linking an existing cel)
+# TODO R: The linked indicator seems to not get updated properly (adding a new linked cel won't show the indicator until another timeline change, same with linking an existing cel)
 func _ready() -> void:
 	button_setup()
 
@@ -103,17 +103,17 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 			_delete_cel_content()
 
 		MenuOptions.LINK:
-			# TODO: See if there is any refactoring to do here:
+			# TODO R: See if there is any refactoring to do here:
 			var f: Frame = Global.current_project.frames[frame]
 			var cel_index: int = Global.current_project.layers[layer].linked_cels.find(f)
 			var new_layers: Array = Global.current_project.duplicate_layers()
 			var new_cels: Array = f.cels.duplicate()
 			for i in new_cels.size():
-				# TODO: This doesn't work (currently replaces ALL cels on the frame)
+				# TODO H: This doesn't work (currently replaces ALL cels on the frame)
 				new_cels[i] = PixelCel.new(
 					new_cels[i].image, new_cels[i].opacity, new_cels[i].image_texture
 				)
-# TODO: Make sure all this stuff still works after refactor:
+# TODO R: Make sure all this stuff still works after refactor:
 			if popup_menu.get_item_metadata(MenuOptions.LINK) == "Unlink Cel":
 				new_layers[layer].linked_cels.remove(cel_index)
 				var sprite := Image.new()
@@ -197,7 +197,7 @@ func can_drop_data(_pos, data) -> bool:
 	if typeof(data) == TYPE_ARRAY and data[0] == "PixelCel":
 		var drag_frame = data[1]
 		var drag_layer = data[2]
-		# TODO: Is this part really right? Should't it only matter if they're linked, and we're changing layers?
+		# TODO L: Is this part really right? Should't it only matter if they're linked, and we're changing layers?
 		#		It would need to add linked cel logic to project move/swap_cel though
 		# If the cel we're dragging or the cel we are targeting are linked, don't allow dragging
 		if not (
@@ -207,7 +207,7 @@ func can_drop_data(_pos, data) -> bool:
 				in Global.current_project.layers[drag_layer].linked_cels
 			)
 		):
-			# TODO: This may be able to be combined with the previous condition depending on the the last TODO
+			# TODO L: This may be able to be combined with the previous condition depending on the the last TODO
 			if not (drag_frame == frame and drag_layer == layer):
 				var region: Rect2
 				if Input.is_action_pressed("ctrl") or layer != drag_layer: # Swap cels

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -104,7 +104,6 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 
 		MenuOptions.LINK:
 			# TODO R3: If you do part of linked cels in add/remove frames, consider changes here:
-			# TODO R4: Make add_do/undo_property/method order consistent (and make sure it doesn't cause issues)
 			var project: Project = Global.current_project
 			var f: Frame = project.frames[frame]
 			var cel_index: int = project.layers[layer].linked_cels.find(f)
@@ -150,8 +149,8 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 			project.undo_redo.add_do_method(Global.animation_timeline, "project_cel_added", frame, layer)
 			project.undo_redo.add_undo_method(Global.animation_timeline, "project_cel_added", frame, layer)
 
-			project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 			project.undo_redo.add_do_method(Global, "undo_or_redo", false)
+			project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
 			project.undo_redo.commit_action()
 
 

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -213,10 +213,10 @@ func can_drop_data(_pos, data) -> bool:
 				if Input.is_action_pressed("ctrl") or layer != drag_layer: # Swap cels
 					region = get_global_rect()
 				else: # Move cels
-					if _get_region_rect(0, 0.5).has_point(get_global_mouse_position()):
+					if _get_region_rect(0, 0.5).has_point(get_global_mouse_position()): # Left
 						region = _get_region_rect(-0.125, 0.125)
 						region.position.x -= 2  # Container spacing
-					else:
+					else: # Right
 						region = _get_region_rect(0.875, 1.125)
 						region.position.x += 2  # Container spacing
 				Global.animation_timeline.drag_highlight.rect_global_position = region.position
@@ -281,10 +281,14 @@ func drop_data(_pos, data) -> void:
 	else: # Move cels
 		var to_frame: int
 		# TODO: Test that this is correct: (after cel button ui changes)
-		if _get_region_rect(0, 0.5).has_point(get_global_mouse_position()):
+		# TODO: This breaks sometimes (after several tests usually), I'm not sure what the condition it breaks in is, maybe need to draw it out?
+		#		(This is probably an error in the project.move_cel function)
+		if _get_region_rect(0, 0.5).has_point(get_global_mouse_position()): # Left
 			to_frame = frame
-		else:
+		else: # Right
 			to_frame = frame + 1
+		if drop_frame < frame:
+			to_frame -= 1
 		project.undo_redo.add_do_method(project, "move_cel", drop_frame, to_frame, layer)
 		project.undo_redo.add_undo_method(project, "move_cel", to_frame, drop_frame, layer)
 

--- a/src/UI/Timeline/PixelCelButton.gd
+++ b/src/UI/Timeline/PixelCelButton.gd
@@ -123,6 +123,9 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 				new_layers[layer].linked_cels.remove(cel_index)
 				var sprite := Image.new()
 				sprite.copy_from(f.cels[layer].image)
+				# TODO L: In PixelCel's image setter, setting the iamge already calls create_from_image on the texture,
+				# 			so I think its getting called twice, setting the new image texture first and then setting
+				#			the image should work without having to call create_from_image here:
 				var sprite_texture := ImageTexture.new()
 				sprite_texture.create_from_image(sprite, 0)
 				new_cels[layer].image = sprite


### PR DESCRIPTION
Refactor of how adding/removing/moving Layers, Cels, and Frames works.
- Created add/remove/move/swap_frame(s)/layer(s)/cel(s) methods to Project class. When the user presses the add layer button, drags and drops a frame, etc. the methods responding to those actions will call these functions in do/undo. These methods are reversible (swap add and remove on undo/redo, or swap parameters on the move and swap methods). When these methods are called, they call the new project_frame/layer/cel_added/removed methods in AnimationTimeline that create or remove frame, layer, and/or cel buttons.
- Moved the timeline portion of Project.change_project to AnimationTimeline.project_changed and rewrote it.
- Rewrote and combined Project's _toggle_layer_buttons_layers and _toggle_layer_buttons_current_layer methods into a simpler single _toggle_layer_buttons method.
- Removed code:
  - Project.frames and Project.layers setters: _frames_changed and _layers_changed
  - Removed the "Frame" and "Move Cels" parts of Global.undo_or_redo (Made changes to make what's needed happen elsewhere)
  - Project.remove_cel_buttons
- Some small readability tweaks
  - Use a project variable in several methods to prevent super long lines like: Global.current_project.layers[Global.current_project.current_layer]
  - Renamed some method variables
- Several tweaks to the new versions of layer/cel classes
  - Added create_layer/cel_button methods to Layer and Cel classes, using polymorphism to limit the amount of places you would need to edit to add new layer types, and avoid having growing if/else branches in various functions.
    - The PackedScene resources for these are now loaded in a variable in Global. (Originally I just used load in the create_layer/cel_button methods right before instancing (preload couldn't be used because of cyclic references), however when testing performance on large projects, I noticed that the loading projects and changing tabs took twice as long, due to the the button PackedScene being constantly freed after creating each instance and reloaded).
  - Modified how is_expanded_in_timeline works
  - Added copy, copy_cel, and copy_all_cels methods to Layer classes
  - Changed get_default_name to set_name_to_default in Layer classes

Features:
- The entire UI for Layers, Cels, and Frames is no longer destroyed and recreated for each change (just where the change happened), so performance with lots of Layers and/or Frames is greatly improved:

https://user-images.githubusercontent.com/65431647/180324982-dfe6099c-a3b9-466b-9f42-68cf797f4752.mp4

(Borrowed the splash screen by Roroto to have a project with lots of frame to test)

- On Layers, Cels, and Frames, dragging will now move them by default, with the previous swapping behavior being usable when holding Control
  - Cels will always swap on different layers to make sure each layer has the same amount of cels, would it be better to simply not allow dragging and dropping them to different layers without Control held for consistency?
  - Drag and drop highlight

https://user-images.githubusercontent.com/65431647/180324682-1d8e1730-47c1-4886-ad0b-dcd7fc6ea157.mp4

- Made move up/down layer buttons and delete layer button work with the hierarchy.

https://user-images.githubusercontent.com/65431647/180324797-a3caee2c-2101-4ffa-8946-b522d02c5958.mp4



Fixes:
- When changing projects, in the timeline show the project's selected cels as the selection, rather than the current layer/frame (this was a bug in Pixelorama master)